### PR TITLE
Body assembly parts

### DIFF
--- a/Mechanical/Body Assembly/Latex Doc/Body Build Doc.tex
+++ b/Mechanical/Body Assembly/Latex Doc/Body Build Doc.tex
@@ -207,13 +207,10 @@ The differential pivot is used to transfer weight off of the wheel that is curre
         \hline
         \thead{Item} & \thead{Ref} & \thead{Qty} & \thead{Image} & \thead{Item} & \thead{Ref} & \thead{Qty} & \thead{Image} \\
         \hline
-        Single Hole Pattern Bracket & S8 & 1 & \partimg{../../../images/parts_list/S8.jpg} & \#6-32x1/4" Spacer & T1 & 8 & \partimg{../../../images/parts_list/T1.png} \\ \hline
-        0.5" Pillow Bearing Block & S11 & 2 & \partimg{../../../images/parts_list/S11.jpg} & \#6-32x1/4" Button Head Screw & B1 & 6 & \partimg{../../../images/parts_list/B1.png} \\ \hline
-        0.5" Circular Clamping Hub & S13 & 1 & \partimg{../../../images/parts_list/S13.png} & \#6-32x1" Button Head Screw & B6 & 4 & \partimg{../../../images/parts_list/B6.png} \\ \hline
-        0.5"x2" Aluminum Rod & S19 & 1 & \partimg{../../../images/parts_list/S19.jpg} & 0.5" Plastic Washer & W3 & 3 & \partimg{../../../images/parts_list/W3.png} \\ \hline
-        0.5" Bottom Bore Clamp & S20 & 2 & \partimg{../../../images/parts_list/S20.jpg} & Allen Key Set & & & \partimg{../../../images/parts_list/D2.jpeg} \\ \hline
-        Collar Clamp & S22 & 1 & \partimg{../../../images/parts_list/S22.png} & 5/16" Wrench & & & \partimg{../../../images/parts_list/D1.jpg} \\ \hline
-    \end{tabular}
+        \#6-32x1/4" Spacer & T1 & 8 & \partimg{../../../images/parts_list/T1.png} & 0.5" Pillow Bearing Block & S11 & 2 & \partimg{../../../images/parts_list/S11.jpg} \\ \hline
+        \#6-32x1" Button Head Screw & B6 & 4 & \partimg{../../../images/parts_list/B6.png} &  Allen Key Set & & & \partimg{../../../images/parts_list/D2.jpeg} \\ \hline 
+        5/16" Wrench & & & \partimg{../../../images/parts_list/D1.jpg} & & & & \\ \hline
+      \end{tabular}
 \end{table}
 
 \begin{enumerate}

--- a/Mechanical/Body Assembly/Latex Doc/Body Build Doc.tex
+++ b/Mechanical/Body Assembly/Latex Doc/Body Build Doc.tex
@@ -135,7 +135,7 @@ Next we need to drill a hole in one of the 9x12 Aluminum plates \textbf{S35} bec
         \hline
         1.5" Channel & S1 & 4 & \partimg{../../../images/parts_list/S1.jpg} & \#6-32x3/8" Button Head Screw & B2 & 16 & \partimg{../../../images/parts_list/B2.png} \\ \hline
         4.5"x12" Aluminum Plate & S37 & 2 & \partimg{../../../images/parts_list/S37.jpg} & \#6-32x1" Button Head Screw & B6 & 4 & \partimg{../../../images/parts_list/B6.png} \\ \hline
-        1" PVC Clamp & S24 & 1 & \partimg{../../../images/parts_list/S24.jpg} & \#6-32 Locking Hex Nut & B11 & 20 & \partimg{../../../images/parts_list/B11.png} \\ \hline
+        1" PVC Clamp & S24 & 1 & \partimg{../../../images/parts_list/S24.jpg} & \#6-32 Locking Hex Nut & B11 & 16 & \partimg{../../../images/parts_list/B11.png} \\ \hline
         9"x12" Aluminum Plate & S35A & 1 & \partimg{../../../images/parts_list/S35.jpg} & Allen Key Set & & & \partimg{../../../images/parts_list/D2.jpeg} \\ \hline
         \#6-32x1/4" Button Head Screw & B1 & 4 & \partimg{../../../images/parts_list/B1.png} & 5/16" Wrench & & & \partimg{../../../images/parts_list/D1.jpg} \\ \hline
     \end{tabular}


### PR DESCRIPTION
Updates to the parts list in the Body Assembly. Table 1 was updated by Mic in 528430eb1642f58e5439beb6030c5c63224b2b39, but we need to decrease the amount of hex nuts (B11) by 4 as well.

Additionally, Table 2 in the same Body Assembly section has a myriad of parts that are not used in this section. My guess is they were at one time (probably in history?) but when the documentation was broken out to make it easier to build, these parts are now used in other sections such as the Differential Pivot Build and Mechanical Integration sections. From what I can tell, each part can be found in those sections correctly, but just needs to be removed from here. I'll know for sure when I get to those sections of my build.