### PR TITLE
Add kitspace files

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,15 +183,29 @@ In order to help this ordering process we have compiled a few links of a large n
 |[McMaster](https://www.mcmaster.com/order/rcvRtedOrd.aspx?ordid=5887891246&lnktyp=txt)|[Amazon](https://www.amazon.com/gp/registry/wishlist/3ELV1FY8J7ZYP/ref=cm_sw_em_r_z_g__wb)|[Pololu](https://www.pololu.com/wishlist/1J10953)|[Adafruit](https://www.adafruit.com/wishlists/460400)|
 |---|---|---|---|
 
-**Digikey:** 
-The Bill of Materials folder contains (currently just one) Bill of materials file for a specific vendor. We are searching for better ways to help with the ordering process, however for now the easiest way is to take the [Digikey Bill of Materials](bill_of_materials/Digikey_BOM.csv) and upload it to [Digikey](https://www.digikey.com/). You can find the "BOM Manager" on their homepage and then start a new BOM, where you can upload this file.
+**Electronics**
+
+The easiest way to buy the electronics parts is to use the links (to e.g. Digikey) on the Kitspace pages:
+
+- [control-board](https://kitspace.org/boards/github.com/nasa-jpl/open-source-rover/open-source-rover-control-board/)
+- [arduino-shield](https://kitspace.org/boards/github.com/nasa-jpl/open-source-rover/open-source-rover-shield/)
+
+Another way to order from Digikey is to upload the [Digikey Bill of Materials](bill_of_materials/Digikey_BOM.csv) at [Digikey.com](https://www.digikey.com/).
 
 #### 3D printing and Laser cutting
 
 In addition to ordering all of the parts on the parts list, we recommend that some pieces be 3D printed and laser cut. If you do not have access to a 3D printer or laser cutter, we've added some online services as examples for where you can get those manufactured and shipped to you. You'll find instructions on this in the [Body Build Doc](mechanical/body_assembly/README.md),  [Corner Steering Build Doc](mechanical/corner_steering/README.md), and [Head Assembly Build Doc](mechanical/head_assembly/README.md).
 
 #### Printed Circuit Boards (PCBs)
-The main electrical system of this rover relies on a custom printed circuit board (PCB) that handles the routing between the majority of the electrical components.  This board greatly simplifies the build process and eliminates the need for you to route all the wires yourself. You can find the PCB board files at [PCB Files](https://github.com/nasa-jpl/open-source-rover/tree/master/electrical/pcb). These can be ordered at [JLCPCB](https://jlcpcb.com/) by dropping each of the .zip files (these .zip files contain "gerber" files, a typical file format for PCB boards).
+
+The main electrical system of this rover relies on a custom printed circuit board (PCB) that handles the routing between the majority of the electrical components. This board greatly simplifies the build process and eliminates the need for you to route all the wires yourself. You can find the PCB board files at [PCB Files](https://github.com/nasa-jpl/open-source-rover/tree/master/electrical/pcbelectrical/pcb/).
+
+The easiest way to order the PCBs is through the links (to e.g JLCPCB) on the Kitspace pages:
+
+- [control-board](https://kitspace.org/boards/github.com/nasa-jpl/open-source-rover/open-source-rover-control-board/)
+- [arduino-shield](https://kitspace.org/boards/github.com/nasa-jpl/open-source-rover/open-source-rover-shield/)
+
+You can also download the "Gerber" files there (a typical file format for PCBs) and upload them to any other PCB service that doesn't have a direct link on Kitspace.
 
 ---
 

--- a/electrical/pcb/arduino_uno_sheild/BOM.csv
+++ b/electrical/pcb/arduino_uno_sheild/BOM.csv
@@ -1,0 +1,5 @@
+References,Qty,Description,Manufacturer,MPN,Digikey,Mouser,RS,Newark,Farnell
+J1,1,Connector Header 16P 2x8,ASSMANN WSW Components,H3CCH-1606G,H3CCH-1606G-ND,,,,
+"J2, J3, J4",1,Connector Header pin 40P 40x1,Sullins,PRPC040SAAN-RC,S1011EC-40-ND,,,,
+J5,1,Connector Header 6P 6x1,JST,B6B-PH-K-S(LF)(SN),455-1708-ND,,8201447,,9492453
+J6,1,Term block 2P side entry,Phoenix Contact,1984617,277-1721-ND,6511984617,6488484,,2776442

--- a/electrical/pcb/control_board/BOM.csv
+++ b/electrical/pcb/control_board/BOM.csv
@@ -1,0 +1,20 @@
+References,Qty,Description,Manufacturer,MPN,Digikey,Mouser,RS,Newark,Farnell
+"C1, C12, C13, C14, C15, C17, C3, C5, C4, C2, C10, C9, C8, C7, C6, C11, C16",17,100nF axial,KEMET,C410C104M5U5TA7200,399-4454-1-ND,80C410C104M5UTR,,,1650914
+D1,1,Power Diode,STMicroelectronics,STPS10L25D,497-2738-5-ND,511STPS10L25D,7958795,,9803360
+F1,1,10A Fuse,Bel Fuse,0697H9100-01,507-1916-ND,5300697H910001,,,
+J10,1,Connector Header pin 6P 6x1,JST,B6B-PH-K-S(LF)(SN),455-1708-ND,,8201447,,9492453
+J13,1,Term block 2p side entry (3.5mm),On Shore Technology,ED550/2DS,ED1501-ND,,,,
+"J14, J12",2,USB Conn ED2989-ND-USB,On Shore Technology,USB-A1HSW6,ED2989-ND,,,,
+"J15, J16, J16",3,ED2580-ND,On Shore Technology,OSTTA024163,ED2580-ND,,,,
+"J17, J25, J21, J20, J19, J24, J22, J18, J23, J26",10,Terminal block 6 pos side entry,On Shore Technology,OSTTE060104,ED2744-ND,,,,
+"J5, J1, J4, J3, J2",5,Terminal block 6 pos top entry,On Shore Technology,OSTTF060161,ED2627-ND,,,,
+"J7, J6",1,S9175-ND,Sullins,SBH11-PBPC-D20-ST-BK,S9175-ND,,,,
+J8,1,6x1 Header Pin 0.1 Pitch 6posheader,Sullins,PRPC040SAAN-RC,S1011EC-40-ND,,,,
+"J9, J11",2,S7038-ND,Sullins,PPPC051LFBN-RC,S7038-ND,,,,
+R1,1,Resistor 4.7K 1/4 Watt,Stackpole Electronics,CF14JT4K70,CF14JT4K70CT-ND,,,,
+R2,1,Resistor 10K 1/2 Watt,Stackpole Electronics,CFM12JT10K0,S10KHCT-ND,,,,
+"R7, R9, R5, R3",4,Resistor 22K 1/4 Watt,Stackpole Electronics,CF14JT22K0,CF14JT22K0CT-ND,,,,
+"R8, R10, R6, R4",4,Resistor 10K 1/4 Watt,Stackpole Electronics,CF14JT10K0,CF14JT10K0CT-ND,,,,
+"RC4, RC2, RC1, RC3, RC5",5,Connector Header socket 20 2x10,Sullins,PPPC102LFBN-RC,S6106-ND,,,,
+"U2, U1",2,LM358-N,Texas Instruments,LM358P,296-1395-5-ND,595LM358P,,,
+"U2, U1",2,,ASSMANN WSW Components,A 08-LC-TT,AE9986-ND,,6742435,,

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,17 @@
+multi:
+  open-source-rover-shield:
+    summary: Arduino shield for a 6-wheel rover based on the rovers on Mars!
+    site: https://opensourcerover.jpl.nasa.gov/
+    readme: README.md
+    bom: electrical/pcb/arduino_uno_sheild/BOM.csv
+    eda:
+      type: kicad
+      pcb: electrical/pcb/arduino_uno_sheild/Arduino_uno_sheild.kicad_pcb
+  open-source-rover-control-board:
+    summary: Control board for a 6-wheel rover based on the rovers on Mars!
+    site: https://opensourcerover.jpl.nasa.gov/
+    readme: README.md
+    bom: electrical/pcb/control_board/BOM.csv
+    eda:
+      type: kicad
+      pcb: electrical/pcb/control_board/Control_Boards.kicad_pcb


### PR DESCRIPTION
Hey, as discussed in #144, finally got around to making this compatible with [kitspace.org](https://kitspace.org).

- Here is a [preview](http://add-rover.preview.kitspace.org/).
- Along the way I fixed some issues with the BOM/parts list (df517f9) but I couldn't rebuild the PDFs using latex (I am on a case-sensitive file system which meant it can't find the images). 
- I also fixed the spelling of "shield" throughout, though I haven't tested extensively if this rename has caused unforeseen issues (KiCad still seems to open the design fine). 
- I was a bit confused about the "Monolithic Board". Should those files just be deleted?