### PR TITLE
Remove duplicate "#" from fragment identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The specific attributes of the robot you build will depend slightly on the type 
 
 Again, the above statistics depend on which components you select when buying parts. One potential change is for the motors; you can, for example, select higher RPM motors (to drive your rover faster) at the sacrifice of max stall torque, which would potentially limit your rover's ability to climb. A selection of motors that would integrate easily with the rest of the suggested rover design can be found at [GoBilda](https://www.gobilda.com/5202-series-yellow-jacket-planetary-gear-motors/).
 
-(*) Other open-source, cheaper alternatives exist but are slower, less strong, and are more fragile. See [Additional Projects](##additional-projects).
+(*) Other open-source, cheaper alternatives exist but are slower, less strong, and are more fragile. See [Additional Projects](#additional-projects).
 
 ### Features
 This rover is designed to function similarly to the 6 wheel rover designs on Mars and employs a few of the major driving mechanics that the mars rovers use to traverse rocky surfaces:


### PR DESCRIPTION
Corrects a broken link in the rendered Markdown.