### PR TITLE
Remove Git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "Software/android_app"]
-	path = Software/android_app
-	url = https://github.com/nasa-jpl/osr-android-app
-[submodule "Software/rover-code"]
-	path = Software/rover-code
-	url = https://github.com/nasa-jpl/osr-rover-code


### PR DESCRIPTION
If installed follow this process to remove local Git submodules:

1. Merge in nasa-jpl:master to which removes the `.gitmodules` file.
2. Delete the following sections from `.git/config`:

```
[submodule "Software/android_app"]
    url = https://github.com/nasa-jpl/osr-android-app
    active = true
[submodule "Software/rover-code"]
    url = https://github.com/nasa-jpl/osr-rover-code
    active = true
```

3. Run `git rm --cached Software/android_app` and `git rm --cached Software/rover-code`.
4. Delete the now untracked submodule files with `rm -r Software/android_app` and `rm -r Software/rover-code`.

Closes #271