### PR TITLE
Adding version table and release notes for rover project version

### DIFF
--- a/release_notes/project_v2_0_0.md
+++ b/release_notes/project_v2_0_0.md
@@ -1,0 +1,25 @@
+### Project v2.0.0
+
+This is our first "real" release of the project with a formal version. The idea is to do better version tracking going forward. 
+
+Important characteristics of this version:
+
+#### Hardware
+
+{Link to github tag}
+
+Key features:
+- [Pololu DC drive motors](https://www.pololu.com/product/4888)
+- [Actobotics planetary gear corner motors](https://www.servocity.com/45-rpm-hd-premium-planetary-gear-motor)
+- [Servocity aluminum plates](https://www.servocity.com/9-x-12-aluminum-pattern-plate/) for top and bottom of body frame
+- [Traxxas wheels](https://www.dollarhobbyz.com/collections/all/products/traxxas-2-talon-tires-gemini-black-chrome-wheels-5374x)
+- PCB revE
+- RPi 3 or 4 supported
+
+#### Software
+
+{Link to github tag}
+
+Key features:
+- ROS1 on Ubuntu 18.04
+- Development branch for ROS2 on Ubuntu 20.04

--- a/versions.md
+++ b/versions.md
@@ -1,0 +1,13 @@
+# Open Source Rover Versions
+
+## Versions Table
+
+| Date             | Project Version  | Hardware Version   | Software Version    | 
+| ----------       | ----------       |:-----:             | :-------------:     |
+| May 24, 2021     | v2.0.0           | v2.0.0             | v2.0.0              |
+
+## Release Notes
+
+Note that project v2.0.0 was the first formally versioned release.
+
+- [v2.0.0](release_notes/project_v2_0_0.md)


### PR DESCRIPTION
This table will be the source of truth for keeping track of versions of the hardware software and aligning them with each other.

Idea is to always bump the project version whenever either the hardware or the software version changes. Feels a little manual, but I think it's all right.

Also creating a release notes directory. Would be good to include a release notes for every _significant_ update of the hardware and software (and thus project version)