### PR TITLE
Fix control board pcb path in kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -14,4 +14,4 @@ multi:
     bom: electrical/pcb/control_board/BOM.csv
     eda:
       type: kicad
-      pcb: electrical/pcb/control_board/Control_Boards.kicad_pcb
+      pcb: electrical/pcb/control_board/Control Board.kicad_pcb


### PR DESCRIPTION
Not quite sure how this mistake slipped through when I did the preview. Sorry about that. 