### PR TITLE
Fix heading syntax

### DIFF
--- a/mechanical/head_assembly/README.md
+++ b/mechanical/head_assembly/README.md
@@ -165,7 +165,7 @@ Take the Arduino Plate assembly and mount it using screws B8 to the heat set ins
 |:-:|:-:|
 | Figure 15 | Figure 16 |
 
-##6.7 Back Plate Attachment
+## 6.7 Back Plate Attachment
 
 Attach the Laser Cut Back Plate S42 onto the back of the head assembly using screws B2.
 


### PR DESCRIPTION
There must be a space between the `#` and heading text so that the GitHub Markdown parser correctly renders a heading.