### PR TITLE
Remove duplicate parts S28 and S33 from parts list

### DIFF
--- a/parts_list/master_parts_list_raw.csv
+++ b/parts_list/master_parts_list_raw.csv
@@ -84,13 +84,11 @@ Dual Side mount A,S17,585470,ServoCity,https://www.servocity.com/90-dual-side-mo
 3D Printed PVC Clamping Hub (top),S24,,Makexyz,https://www.makexyz.com/,1,1,1,$12.90 ,$12.90 ,Head Assembly
 Plain Bore Gear,S26,RHA32-36-48,ServoCity,https://www.servocity.com/32-pitch-acetyl-hub-gears-0-1875-face#199=15,1,4,4,$5.20 ,$20.80,Wheel Assembly
 Shaft Mount Pinion Gear (16 Tooth),S27,KPL32-32-16,ServoCity,https://www.servocity.com/0-125-1-8-bore-32p-shaft-mount-pinion-gears-steel#199=100,1,4,4,$5.99 ,$23.96,Corner Steering
-Custom Acrylic Electronics Board,S28,,Sculpteo,https://www.sculpteo.com/,1,1,1,$15.25 ,$15.25,
 5 Foot PVC,S29,48925K93,McMaster,https://www.mcmaster.com/48925k93,1,1,1,$5.28 ,$5.28,Head Assembly
 "3.75"" Channel",S3,585443,ServoCity,https://www.servocity.com/3-75-channel,1,4,4,$4.49 ,$17.96,Rocker-Bogie
 Wheel,S30,,DollarHobbyz,https://www.dollarhobbyz.com/collections/all/products/traxxas-2-talon-tires-gemini-black-chrome-wheels-5374x,2,6,3,$25.27 ,$75.81,Wheel Assembly
 3D Printed Encoder Mounts,S31,,Makexyz,https://www.makexyz.com/,1,4,4,$12.90 ,$51.60,Corner Steering
 RC Turnbuckles,S32,06048B,Amazon,https://www.amazon.com/Hobbypark-Aluminum-Turnbuckle-BRONTOSAURUS-Replacement/dp/B01H5PZKMK,2,2,1,$9.25 ,$9.25,Differential Pivot
-3D Printed Head,S33,,Makexyz,https://www.makexyz.com/,1,1,1,$75.80 ,$75.80,
 Loctite Red,S34,,Amazon,https://www.amazon.com/Loctite-Threadlocker-Red-0-20-209741/dp/B000FP8EUS,1,1,1,$6.49 ,$6.49,Wheel Assembly
 9 x 12 Top Plate,S35,,Sculpteo,https://www.sculpteo.com/,1,1,1,$12.06 ,$33.98 ,Body
 Loctite 2 Part Apoxy,S36,,Amazon,https://www.amazon.com/Loctite-Marine-0-85-Fluid-Syringe-1405604/dp/B00KH62K50,1,1,1,$5.42 ,$5.42,Wheel Assembly


### PR DESCRIPTION
1. Remove S33 as it is a duplicate of S43.
2. Remove S28 as it is duplicate of S44.

Closes #334