### PR TITLE
Add soldering iron to list of required tools

### DIFF
--- a/mechanical/body_assembly/README.md
+++ b/mechanical/body_assembly/README.md
@@ -30,6 +30,7 @@ The body is the housing of all the electronics for the rover. It is the attachme
   * Band saw or Dremel
   * Allen Key set
   * Imperial Wrench Set
+  * Soldering Iron
 
 #### 2.2.2 Optional
   * Laser cutter

--- a/mechanical/head_assembly/README.md
+++ b/mechanical/head_assembly/README.md
@@ -31,6 +31,7 @@ The head assembly serves as the head and face of our rover. It houses a 16x32 fu
   * Drill press or Hand Drill
   * Allen Key set
   * Imperial Wrench Set
+  * Soldering Iron
 
 ### 2.2.2 Optional
 


### PR DESCRIPTION
A soldering iron is required to fit heat set inserts.

Add a soldering iron as a required tool to:

* `mechanical/body_assembly/README.md`
* `mechanical/head_assembly/README.md`