### PR TITLE
Absolute link to GitHub directory listing

### DIFF
--- a/electrical/README.md
+++ b/electrical/README.md
@@ -16,7 +16,7 @@ If you do wish to purchase these boards/items previous to the final release to h
 
 [Master Parts List](../parts_list/master_parts_list_raw.csv)
 
-In here currently are just the gerber files necessary to order the boards in their current revision. Eventually I will upload the libraries/kicad files so everyone can make edits to them, but in order to just get information up here it will just be the gerbers at first. They can be found in [the PCB folder](/electrical/pcb/).
+In here currently are just the gerber files necessary to order the boards in their current revision. Eventually I will upload the libraries/kicad files so everyone can make edits to them, but in order to just get information up here it will just be the gerbers at first. They can be found in [the PCB folder](https://github.com/nasa-jpl/open-source-rover/tree/master/electrical/pcb).
 
 To order these boards we suggest that you order from [JLCPCB](https://jlcpcb.com/), this PCB fabrication company is quite inexpensive for this board size and has good turnaround time. Upload the .zip files individually and make sure the following settings are set:
 


### PR DESCRIPTION
Fix a link to a GitHub.com directory listing. So the link is not broken when the documentation is built with MkDocs #360.