### PR TITLE
Fix Read the Docs Build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+  - requirements: requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: JPL Open Source Rover
-site_url: https://osr-demo.readthedocs.io
+site_url: https://open-source-rover.readthedocs.io
 site_description: |
   A build-it-yourself, 6-wheel rover based on the rovers on Mars!
 copyright: |


### PR DESCRIPTION
As of 2023-09-25 Read the Docs requires a `.readthedocs.yaml` configuration file.

See https://blog.readthedocs.com/migrate-configuration-v2/