### PR TITLE
Fixes/prunes broken nav links.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,25 +15,19 @@ nav:
   - Home: README.md
   - Electrical:
       - Overview: electrical/README.md
+      - Wiring: electrical/wiring/README.md
       - PCB assembly: electrical/pcb/README.md
-      - Build: electrical/electrical_build.md
-      - Calibration: electrical/calibration.md
   - Mechanical:
-      - Subsystem: mechanical/README.md
-      - Body assembly: mechanical/body_assembly/README.md
-      - Corner steering: mechanical/corner_steering/README.md
-      - Differential pivot: mechanical/differential_pivot/README.md
-      - Head assembly: mechanical/head_assembly/README.md
-      - Integration: mechanical/mechanical_integration/README.md
-      - Rocker bogie: mechanical/rocker_bogie/README.md
+      - Overview: mechanical/README.md
       - Wheel assembly: mechanical/wheel_assembly/README.md
+      - Body: mechanical/body/README.md
+      - Rocker bogie: mechanical/rocker_bogie/README.md
   - Parts:
       - Parts list: parts_list/README.md
-      - Optional parts: optional_cad_parts/README.md
+      - Optional parts: mechanical/optional_cad_parts/README.md
   - Software:
-      - software/README.md
       - Software on GitHub: https://github.com/nasa-jpl/osr-rover-code
-  - OSR@JPL: https://opensourcerover.jpl.nasa.gov
+  - OSR@JPL: https://jplopensourcerover.com/
 
 plugins:
   - same-dir


### PR DESCRIPTION

I ran MkDocs locally and tracked down the broken links in the navigation. Here are the details for the individual changes:

* Changes nav link from https://opensourcerover.jpl.nasa.gov/ to https://jplopensourcerover.com/. The .gov site is down and it looks like https://jplopensourcerover.com/ is the replacement but tbh there's no certain way to verify this.
* Adds missing links to mechanical/body/README.md and electrical/wiring/README.md. Reorders mechanical section to reflect build order.
* Updates link from optional_cad_parts/README.md to mechanical/optional_cad_parts/README.md. File was moved in https://github.com/nasa-jpl/open-source-rover/commit/35d8e9b8dfa5b18606525ca6f32d82a556ae108d. The file is out of date though so maybe this link should be removed.
* Removes links to software/README.md, mechanical/body_assembly/README.md, and electrical/calibration.md. Files were deleted in https://github.com/nasa-jpl/open-source-rover/commit/35d8e9b8dfa5b18606525ca6f32d82a556ae108d. Calibration is now covered in step 6 of electrical/pcb/README.md. 
* Removes link to mechanical/head_assembly/README.md. File was deleted in https://github.com/nasa-jpl/open-source-rover/commit/c0c87c3b9199a678518b7424c7def7a582ef7efa.
* Removes link to mechanical/differential_pivot/README.md. File was deleted in https://github.com/nasa-jpl/open-source-rover/commit/d092d83f064c61b13fc12ecb0f11a1fb6be38111.
* Removes links to mechanical/corner_steering/README.md and mechanical/mechanical_integration/README.md. Files were deleted in https://github.com/nasa-jpl/open-source-rover/commit/6113a692730ea601d4d2d8011f8c5e4d7513b98e.
* Removes link to electrical/electrical_build.md. File was deleted in https://github.com/nasa-jpl/open-source-rover/commit/7037209e7fcc6121d667680de5088e9ac6a1c9d4.

There are still some warnings from MkDoc that aren't addressed:

```
$ mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
              - electrical/pcb/control_board/readme.md
              - electrical/pcb/control_board/BOM/v2.0.0/README.md
              - electrical/pcb/control_board/BOM/v2.0.1/README.md
              - electrical/pcb/control_board/documentation/v2.0.1/README.md
              - examples/README.md
              - mechanical/body/laser_cut_parts/README.md
              - parts_list/extra_parts.md
              - parts_list/screws.md
WARNING  -  Documentation file 'README.md' contains a link to 'LICENSE.txt' which is not found in the documentation files.
WARNING  -  Documentation file 'electrical/pcb/README.md' contains a link to 'electrical/pcb/6.1-RoboClaw-Testing-and-Verification' which is not found in the documentation files.
WARNING  -  Documentation file 'mechanical/rocker_bogie/README.md' contains a link to 'integration/README.md' which is not found in the documentation files.
WARNING  -  Documentation file 'mechanical/wheel_assembly/README.md' contains a link to 'mechanical/electrical/wiring/README.md' which is not found in the documentation files.
WARNING  -  Documentation file 'parts_list/README.md' contains a link to 'parts_list/mechanical/body/laser_cut_parts/README.md' which is not found in the documentation files.
WARNING  -  Documentation file 'parts_list/extra_parts.md' contains a link to 'parts_list/mechanical/body/laser_cut_parts/README.md' which is not found in the documentation files.
WARNING  -  Documentation file 'parts_list/screws.md' contains a link to 'parts_list/parts_list/README.md' which is not found in the documentation files.
INFO     -  Documentation built in 0.41 seconds
INFO     -  [11:04:01] Serving on http://127.0.0.1:8000/
```