### PR TITLE
Swap out wheels to wasteland wheels

### DIFF
--- a/parts_list/csv_to_md.py
+++ b/parts_list/csv_to_md.py
@@ -78,8 +78,7 @@ and should consist of the same parts, just presented in a more readable format. 
 to Digikey.com directly to create a shopping cart.
 Before you place an order, please double check that you have all parts in the right quantities.
 
-The total cost comes out to be **${round(all_assemblies_cost, 2)}** without discounts. If you are an educational builder,
-please join the Slack workspace and enquire about any discounts.
+The total cost comes out to be **${round(all_assemblies_cost, 2)}** without the GoBilda educational discount (15%) and excluding shipping. **note**: GoBilda may change its pricing without notice.
 
 """
 

--- a/parts_list/extra_parts.md
+++ b/parts_list/extra_parts.md
@@ -84,6 +84,13 @@ You will want threadlocker for several screws so that they don't unscrew themsel
 
 > (*) The reason you need 14V is that the 12V regulator needs a [dropout voltage](https://www.pololu.com/product/2855#dropout) on top of the output voltage in order to provide 12V. A 12V battery will not work adequately.
 
+## Different wheels
+
+* The wheels we previously included as the default from [DollarHobbyz](https://www.dollarhobbyz.com/collections/all/products/traxxas-2-talon-tires-gemini-black-chrome-wheels-5374x) are $34.95 per pair of two for a total of $104.85 (excl. shipping), saving ~$135 compared to the default Wasteland wheels. They are a perfectly fine choice but are significantly smaller and require some drilling to fit to the motor hubs.
+* Gobilda also sells a smaller version of the [Wasteland Wheel at 144mm diameter](https://www.gobilda.com/wasteland-wheel-144mm-diameter-52mm-width/). This shaves off $90 compared to the default Wasteland wheels. No drilling is required and these are the same size as the DollarHobbyz wheels.
+
+There is a software parameter where you can easily modify the size of the wheels to account for speed differences.
+
 # Maintaining the Parts List
 
 Parts can become out of stock or discontinued in the future. In this case, the part list can be modified by editing `parts_list.csv`, which covers all the mechanical parts, `digikey_bom.csv`, which covers most of the electrical part, and `extra_parts.md` to cover the rest. After doing so, you can compile to update the `README.md` file using `csv_to_md.py` (The compilation will also happen automatically with a merge). **Do not** edit `README.md` directly, as it will be overwritten by the compilation process. 

--- a/parts_list/extra_parts.md
+++ b/parts_list/extra_parts.md
@@ -86,8 +86,8 @@ You will want threadlocker for several screws so that they don't unscrew themsel
 
 ## Different wheels
 
-* The wheels we previously included as the default from [DollarHobbyz](https://www.dollarhobbyz.com/collections/all/products/traxxas-2-talon-tires-gemini-black-chrome-wheels-5374x) are $34.95 per pair of two for a total of $104.85 (excl. shipping), saving ~$135 compared to the default Wasteland wheels. They are a perfectly fine choice but are significantly smaller and require some drilling to fit to the motor hubs.
-* Gobilda also sells a smaller version of the [Wasteland Wheel at 144mm diameter](https://www.gobilda.com/wasteland-wheel-144mm-diameter-52mm-width/). This shaves off $90 compared to the default Wasteland wheels. No drilling is required and these are the same size as the DollarHobbyz wheels.
+* The wheels we previously included as the default from [DollarHobbyz](https://www.dollarhobbyz.com/collections/all/products/traxxas-2-talon-tires-gemini-black-chrome-wheels-5374x) are $34.95 per pair of two for a total of $104.85 (excl. shipping), saving ~$135 compared to the default Wasteland wheels. They are a perfectly fine choice but require some drilling to fit to the motor hubs.
+* Gobilda also sells a larger version of the [Wasteland Wheel at 192mm diameter](https://www.gobilda.com/wasteland-wheel-192mm-diameter-72mm-width/). This adds $90 total compared to the default Wasteland wheels. No drilling is required.
 
 There is a software parameter where you can easily modify the size of the wheels to account for speed differences.
 

--- a/parts_list/parts_list.csv
+++ b/parts_list/parts_list.csv
@@ -1,5 +1,5 @@
 assembly,short name,part #,long name,link,cost pp ,# req in assy,assembly multiplier
-drive wheel,wheel,3616-0014-0192,"Wasteland Wheel (192mm Diameter, 72mm Width)",https://www.gobilda.com/wasteland-wheel-192mm-diameter-72mm-width/,$39.99,1,6
+drive wheel,wheel,3616-0014-0144,"Wasteland Wheel (144mm Diameter, 52mm Width)",https://www.gobilda.com/wasteland-wheel-144mm-diameter-52mm-width/,$24.99,1,6
 drive wheel,clamping mount,1401-0043-0036,"1401 Series 2-Side, 2-Post Clamping Mount (43mm Width, 36mm Bore) - goBILDA",https://www.gobilda.com/1401-series-2-side-2-post-clamping-mount-43mm-width-36mm-bore/,$6.99,1,6
 drive wheel,motor,5203-2402-0027,"5203 Series Yellow Jacket Planetary Gear Motor (26.9:1 Ratio, 24mm Length 8mm REX™ Shaft, 223 RPM, 3.3 - 5V Encoder)",https://www.gobilda.com/5203-series-yellow-jacket-planetary-gear-motor-26-9-1-ratio-24mm-length-8mm-rex-shaft-223-rpm-3-3-5v-encoder/,$42.99,1,6
 drive wheel,REX bore hub,1310-0016-4008,"1310 Series Hyper Hub (8mm REX™ Bore)",https://www.gobilda.com/1310-series-hyper-hub-8mm-rex-bore/,$7.99,1,6

--- a/parts_list/parts_list.csv
+++ b/parts_list/parts_list.csv
@@ -1,5 +1,5 @@
 assembly,short name,part #,long name,link,cost pp ,# req in assy,assembly multiplier
-drive wheel,wheel,5374X,"Traxxas 5374X Talon Tires, Gemini Wheels, Black Chrome - Dollar Hobbyz",https://www.dollarhobbyz.com/collections/all/products/traxxas-2-talon-tires-gemini-black-chrome-wheels-5374x,$34.95,1,3
+drive wheel,wheel,3616-0014-0192,"Wasteland Wheel (192mm Diameter, 72mm Width)",https://www.gobilda.com/wasteland-wheel-192mm-diameter-72mm-width/,$39.99,1,6
 drive wheel,clamping mount,1401-0043-0036,"1401 Series 2-Side, 2-Post Clamping Mount (43mm Width, 36mm Bore) - goBILDA",https://www.gobilda.com/1401-series-2-side-2-post-clamping-mount-43mm-width-36mm-bore/,$6.99,1,6
 drive wheel,motor,5203-2402-0027,"5203 Series Yellow Jacket Planetary Gear Motor (26.9:1 Ratio, 24mm Length 8mm REX™ Shaft, 223 RPM, 3.3 - 5V Encoder)",https://www.gobilda.com/5203-series-yellow-jacket-planetary-gear-motor-26-9-1-ratio-24mm-length-8mm-rex-shaft-223-rpm-3-3-5v-encoder/,$42.99,1,6
 drive wheel,REX bore hub,1310-0016-4008,"1310 Series Hyper Hub (8mm REX™ Bore)",https://www.gobilda.com/1310-series-hyper-hub-8mm-rex-bore/,$7.99,1,6


### PR DESCRIPTION
It's a fairly big increase in price but they are simpler to attach, require one less seller, and are much bigger (=faster).

Two other options are specified as alternatives.

- [ ] update the build instructions to match new wheels