### PR TITLE
Adds links for Molex 6-pin connectors to parts list.

### DIFF
--- a/parts_list/README.md
+++ b/parts_list/README.md
@@ -185,7 +185,7 @@ You can also use [grommets](https://www.gobilda.com/plastic-grommet-14-1-12-pack
 
 Heat shrink is a must have for keeping cables nice and snug.
 
-Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to get an idea of what you will be building. You'll need crimps and connectors for DuPont, Bullet, XT30, JST, and Molex styles. Crimping doesn't have a 100% success rate, so we recommend getting extras or buying a kit if you're planning on using them for other projects as well. Here are some options for each set you need:
+Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to get an idea of what you will be building. You'll need crimps and connectors for DuPont, Bullet, XT30, and JST styles. Crimping doesn't have a 100% success rate, so we recommend getting extras or buying a kit if you're planning on using them for other projects as well. Here are some options for each set you need:
 
 * A Raspberry Pi ribbon cable, e.g. from [Adafruit](https://www.adafruit.com/product/1988) but available in many places. While you could use header pins for this connection, the cable is the cleanest solution
 * XT30 connectors for the power connections on the motor PCB.
@@ -197,9 +197,6 @@ Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to
 * 6 4-pin JST connections:
   * 6x [premade JST to jumper wires from GoBilda](https://www.gobilda.com/encoder-breakout-cable-4-pos-jst-xh-mh-fc-to-4-x-1-pos-tjc8-mh-fc-300mm-length/)
   * [JST connector kit](https://www.amazon.com/460PCS-XH2-54-Connector-Terminal-Connectors/dp/B09DBGVX5C/ref=sr_1_1_sspa?crid=2NX4ZXCFZGOCK&keywords=jst+connector+kit+4+pin&qid=1690482910&sprefix=jst+connector+kit+4+pin%2Caps%2C140&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
-* 6 6-pin Molex PCI-E connections. Digikey carries a couple options. In either case, be sure to get enough for 6 connectors.
-  * [housings](https://www.digikey.com/en/products/detail/molex/0469920610/5116009) and [pins](https://www.digikey.com/en/products/detail/molex/0039000077/1643440)
-  * [assemblies](https://www.digikey.com/en/products/detail/molex/2153261063/13883006) are sometimes available but the 16 AWG wire may be difficult to work with
 * 4 3pin DuPont and 8 4pin DuPont connectors
   * [DuPont connector kit](https://www.amazon.com/Twidec-Connector-Terminals-Crimping-Connectors/dp/B0B152WRSW/ref=sr_1_1_sspa?keywords=dupont+connector+kit&qid=1690482984&sprefix=DUPont%2Caps%2C190&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
   * Buy precrimped wires+connectors from various sources

--- a/parts_list/README.md
+++ b/parts_list/README.md
@@ -185,7 +185,7 @@ You can also use [grommets](https://www.gobilda.com/plastic-grommet-14-1-12-pack
 
 Heat shrink is a must have for keeping cables nice and snug.
 
-Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to get an idea of what you will be building. You'll need crimps and connectors for DuPont, Bullet, XT30, and JST styles. Crimping doesn't have a 100% success rate, so we recommend getting extras or buying a kit if you're planning on using them for other projects as well. Here are some options for each set you need:
+Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to get an idea of what you will be building. You'll need crimps and connectors for DuPont, Bullet, XT30, JST, and Molex styles. Crimping doesn't have a 100% success rate, so we recommend getting extras or buying a kit if you're planning on using them for other projects as well. Here are some options for each set you need:
 
 * A Raspberry Pi ribbon cable, e.g. from [Adafruit](https://www.adafruit.com/product/1988) but available in many places. While you could use header pins for this connection, the cable is the cleanest solution
 * XT30 connectors for the power connections on the motor PCB.
@@ -197,6 +197,9 @@ Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to
 * 6 4-pin JST connections:
   * 6x [premade JST to jumper wires from GoBilda](https://www.gobilda.com/encoder-breakout-cable-4-pos-jst-xh-mh-fc-to-4-x-1-pos-tjc8-mh-fc-300mm-length/)
   * [JST connector kit](https://www.amazon.com/460PCS-XH2-54-Connector-Terminal-Connectors/dp/B09DBGVX5C/ref=sr_1_1_sspa?crid=2NX4ZXCFZGOCK&keywords=jst+connector+kit+4+pin&qid=1690482910&sprefix=jst+connector+kit+4+pin%2Caps%2C140&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
+* 6 6-pin Molex PCI-E connections. Digikey carries a couple options. In either case, be sure to get enough for 6 connectors.
+  * [housings](https://www.digikey.com/en/products/detail/molex/0469920610/5116009) and [pins](https://www.digikey.com/en/products/detail/molex/0039000077/1643440)
+  * [assemblies](https://www.digikey.com/en/products/detail/molex/2153261063/13883006) are sometimes available but the 16 AWG wire may be difficult to work with
 * 4 3pin DuPont and 8 4pin DuPont connectors
   * [DuPont connector kit](https://www.amazon.com/Twidec-Connector-Terminals-Crimping-Connectors/dp/B0B152WRSW/ref=sr_1_1_sspa?keywords=dupont+connector+kit&qid=1690482984&sprefix=DUPont%2Caps%2C190&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
   * Buy precrimped wires+connectors from various sources

--- a/parts_list/extra_parts.md
+++ b/parts_list/extra_parts.md
@@ -34,7 +34,7 @@ You can also use [grommets](https://www.gobilda.com/plastic-grommet-14-1-12-pack
 
 Heat shrink is a must have for keeping cables nice and snug.
 
-Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to get an idea of what you will be building. You'll need crimps and connectors for DuPont, Bullet, XT30, and JST styles. Crimping doesn't have a 100% success rate, so we recommend getting extras or buying a kit if you're planning on using them for other projects as well. Here are some options for each set you need:
+Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to get an idea of what you will be building. You'll need crimps and connectors for DuPont, Bullet, XT30, JST, and Molex styles. Crimping doesn't have a 100% success rate, so we recommend getting extras or buying a kit if you're planning on using them for other projects as well. Here are some options for each set you need:
 
 * A Raspberry Pi ribbon cable, e.g. from [Adafruit](https://www.adafruit.com/product/1988) but available in many places. While you could use header pins for this connection, the cable is the cleanest solution
 * XT30 connectors for the power connections on the motor PCB.
@@ -46,7 +46,10 @@ Take a look at the [wiring overview](../electrical/wiring/README.md#overview) to
 * 6 4-pin JST connections:
   * 6x [premade JST to jumper wires from GoBilda](https://www.gobilda.com/encoder-breakout-cable-4-pos-jst-xh-mh-fc-to-4-x-1-pos-tjc8-mh-fc-300mm-length/)
   * [JST connector kit](https://www.amazon.com/460PCS-XH2-54-Connector-Terminal-Connectors/dp/B09DBGVX5C/ref=sr_1_1_sspa?crid=2NX4ZXCFZGOCK&keywords=jst+connector+kit+4+pin&qid=1690482910&sprefix=jst+connector+kit+4+pin%2Caps%2C140&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
-* 4 3pin DuPont and 8 4pin DuPont connectors
+* 6 6-pin Molex PCI-E connections. Digikey carries a couple options. In either case, be sure to get enough for 6 connectors.
+  * [housings](https://www.digikey.com/en/products/detail/molex/0469920610/5116009) and [pins](https://www.digikey.com/en/products/detail/molex/0039000077/1643440)
+  * [assemblies](https://www.digikey.com/en/products/detail/molex/2153261063/13883006) are sometimes available but the 16 AWG wire may be difficult to work with
+* 4 3-pin DuPont and 8 4-pin DuPont connectors
   * [DuPont connector kit](https://www.amazon.com/Twidec-Connector-Terminals-Crimping-Connectors/dp/B0B152WRSW/ref=sr_1_1_sspa?keywords=dupont+connector+kit&qid=1690482984&sprefix=DUPont%2Caps%2C190&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
   * Buy precrimped wires+connectors from various sources
 * 12 female 3.5mm Bullet connectors. Make sure you're getting the right size connectors and ones that come insulated.


### PR DESCRIPTION
I thought the parts would be in the parts list as well. It looks like all the wiring and connectors are only listed in parts_list/README.md so I've only updated that page.