### PR TITLE
Minor improvements to wheel assembly instructions

### DIFF
--- a/mechanical/rocker_bogie/README.md
+++ b/mechanical/rocker_bogie/README.md
@@ -74,7 +74,7 @@ Attach the 1-channel U bracket to the long extruded shaft `11118-0024-0288` usin
 
 ### Attach the front and back of the rocker-bogie
 
-Use 4 hurricane nuts and the 45 degree bracket to connect the back and the front of the rocker-bogie using M4 socket screws of length 8mm as in the image below.
+Use 4 hurricane nuts and the 45-degree bracket to connect the front and back of the rocker-bogie with 6mm M4 socket screws, as shown in the image below. Avoid screws longer than 6mm, as they will hit the goRail before fully tightening.
 
 ![bottom view](images/connect45bracket.png)
 

--- a/mechanical/wheel_assembly/README.md
+++ b/mechanical/wheel_assembly/README.md
@@ -1,8 +1,10 @@
 # Wheel Assembly
 
 The wheel assembly attaches the wheels to the motors and mounts the motors to the rest of the rocker-bogie suspension system that makes up the robot chassis. These are relatively simple to assemble.
+ 
 
 <img src="images/wheels.png" width=900/>
+*If you look carefully at the image above you'll notice that the wheel assemblies aren't actual mirror images of each other. For example, notice that the U brackets for the corner wheels are facing different direction on the left and right sides. This is a defect in the OnShape model. When building your rover, you should make the wheel assembiles to be mirror images of each other.*
 
 ## [DollarHobbyz Traxxas Wheels only] Drilling the wheels
 

--- a/mechanical/wheel_assembly/README.md
+++ b/mechanical/wheel_assembly/README.md
@@ -39,13 +39,13 @@ The result excluding wiring should look as follows:
 
 Note that the sides of the rover are mirrored and so you'll be building 2 pairs of similar but not exactly the same subassemblies, as shown in the right image above.
 
-## Assembled corners
-<img src="images/two_corners_assembled.png">
-Mirror image corner wheel assemblies without the wheels attached yet. Wiring with sleeves is visible.
-
 
 Start by laying out the pieces for each corner so you end up with the 2 mirrored pairs. Take the DuPont to 4-pin JST encoder pins you created in [wiring](../electrical/wiring/README.md) and route them through the top low-profile U-channel, the extruded aluminum, and finally through the motor bracket. The DuPont connector should be at the top with the 4-pin JST connector at the bottom, ready to be connected to the motor encoder pins. Route the two motor power cables through the same parts in the opposite direction. Finally, screw the parts together using 3 or 4 button screws inside the U-channel and using 3 or 4 socket screws at the top. Don't tighten the screws too much yet as this will allow you to adjust wiring.
 
 Adjust the wiring so there is minimal wiring inside the channel. Make sure to protect your wiring from chafing or cutting from the sharp aluminum edges! Be careful when adjusting wires so to not damage the plastic shielding and potentially create shorts.
 
 Repeat this for the 3 other corner assemblies.
+
+## Assembled corners
+<img src="images/two_corners_assembled.png">
+Mirror image corner wheel assemblies without the wheels attached yet. Wiring with sleeves is visible.

--- a/mechanical/wheel_assembly/README.md
+++ b/mechanical/wheel_assembly/README.md
@@ -4,7 +4,7 @@ The wheel assembly attaches the wheels to the motors and mounts the motors to th
  
 
 <img src="images/wheels.png" width=900/>
-*If you look carefully at the image above you'll notice that the wheel assemblies aren't actual mirror images of each other. For example, notice that the U brackets for the corner wheels are facing different direction on the left and right sides. This is a defect in the OnShape model. When building your rover, you should make the wheel assembiles to be mirror images of each other.*
+_If you look carefully at the image above, you'll notice that the wheel assemblies aren't actual mirror images of each other. For example, notice that the U brackets for the corner wheels are facing different directions on the left and right sides. This is a defect in the OnShape model. When building your rover, you should make the wheel assemblies mirror images of each other._
 
 ## [DollarHobbyz Traxxas Wheels only] Drilling the wheels
 
@@ -39,8 +39,8 @@ The result excluding wiring should look as follows:
 
 Note that the sides of the rover are mirrored and so you'll be building 2 pairs of similar but not exactly the same subassemblies, as shown in the right image above.
 
-## Assemmbled corners
-<img src="images/two_corners_assembled">
+## Assembled corners
+<img src="images/two_corners_assembled.png">
 Mirror image corner wheel assemblies without the wheels attached yet. Wiring with sleeves is visible.
 
 

--- a/mechanical/wheel_assembly/README.md
+++ b/mechanical/wheel_assembly/README.md
@@ -39,6 +39,11 @@ The result excluding wiring should look as follows:
 
 Note that the sides of the rover are mirrored and so you'll be building 2 pairs of similar but not exactly the same subassemblies, as shown in the right image above.
 
+## Assemmbled corners
+<img src="images/two_corners_assembled">
+Mirror image corner wheel assemblies without the wheels attached yet. Wiring with sleeves is visible.
+
+
 Start by laying out the pieces for each corner so you end up with the 2 mirrored pairs. Take the DuPont to 4-pin JST encoder pins you created in [wiring](../electrical/wiring/README.md) and route them through the top low-profile U-channel, the extruded aluminum, and finally through the motor bracket. The DuPont connector should be at the top with the 4-pin JST connector at the bottom, ready to be connected to the motor encoder pins. Route the two motor power cables through the same parts in the opposite direction. Finally, screw the parts together using 3 or 4 button screws inside the U-channel and using 3 or 4 socket screws at the top. Don't tighten the screws too much yet as this will allow you to adjust wiring.
 
 Adjust the wiring so there is minimal wiring inside the channel. Make sure to protect your wiring from chafing or cutting from the sharp aluminum edges! Be careful when adjusting wires so to not damage the plastic shielding and potentially create shorts.


### PR DESCRIPTION
I added some clarification about the OnShape model not having mirror image representations of the wheel assemblies all the time and I submitted a photo of two corner wheel assemblies, assembled.