### PR TITLE
Add MBSE systems engineering documentation (Arcadia/Capella)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,34 @@ nav:
       - Optional parts: mechanical/optional_cad_parts/README.md
   - Software:
       - Software on GitHub: https://github.com/nasa-jpl/osr-rover-code
+  - Systems Engineering:
+      - Overview: systems_engineering/README.md
+      - Operational Analysis:
+          - Overview: systems_engineering/01_operational_analysis/README.md
+          - Stakeholders: systems_engineering/01_operational_analysis/stakeholders.md
+          - Operational Entities: systems_engineering/01_operational_analysis/operational_entities.md
+          - Operational Activities: systems_engineering/01_operational_analysis/operational_activities.md
+          - Operational Capabilities: systems_engineering/01_operational_analysis/operational_capabilities.md
+      - System Analysis:
+          - Overview: systems_engineering/02_system_analysis/README.md
+          - System Functions: systems_engineering/02_system_analysis/system_functions.md
+          - Capabilities: systems_engineering/02_system_analysis/capabilities.md
+          - Missions: systems_engineering/02_system_analysis/missions.md
+          - Interfaces: systems_engineering/02_system_analysis/interfaces.md
+      - Logical Architecture:
+          - Overview: systems_engineering/03_logical_architecture/README.md
+          - Logical Components: systems_engineering/03_logical_architecture/logical_components.md
+          - Logical Functions: systems_engineering/03_logical_architecture/logical_functions.md
+          - Interfaces: systems_engineering/03_logical_architecture/interfaces.md
+      - Physical Architecture:
+          - Overview: systems_engineering/04_physical_architecture/README.md
+          - Physical Components: systems_engineering/04_physical_architecture/physical_components.md
+          - Physical Functions: systems_engineering/04_physical_architecture/physical_functions.md
+          - Interfaces: systems_engineering/04_physical_architecture/interfaces.md
+      - EPBS Architecture:
+          - Overview: systems_engineering/05_epbs/README.md
+          - Configuration Items: systems_engineering/05_epbs/configuration_items.md
+      - Capella Model: systems_engineering/MBSE_workspace/README.md
   - OSR@JPL: https://jplopensourcerover.com/
 
 plugins:

--- a/systems_engineering/01_operational_analysis/README.md
+++ b/systems_engineering/01_operational_analysis/README.md
@@ -1,0 +1,51 @@
+# Operational Analysis (OA)
+
+**Arcadia Layer 1 of 5**
+
+The Operational Analysis answers the question: **WHY does the system exist?** It describes the operational context — who the stakeholders are, what activities they need performed, and how entities interact — without yet committing to any system solution.
+
+## Purpose
+
+The OA captures the needs of the world that the OSR must satisfy. It is completely solution-agnostic: there is no rover here, only the operational problem to be solved.
+
+## Documents
+
+| Document | Contents |
+|---|---|
+| [Stakeholders](stakeholders.md) | All parties with a stake in the rover's operation |
+| [Operational Entities](operational_entities.md) | Actors and external systems in the operational environment |
+| [Operational Activities](operational_activities.md) | Activities that must be performed to meet stakeholder needs |
+| [Operational Capabilities](operational_capabilities.md) | High-level capabilities the operation must provide |
+
+## Operational Context Summary
+
+The JPL Open Source Rover exists to serve the **STEM education and maker community** by providing a credible, buildable analog of Mars exploration rovers. The operational environment includes:
+
+- **Educators and students** who build, program, and operate the rover
+- **The terrain** the rover traverses (indoor floors, outdoor surfaces, moderate obstacles)
+- **Compute and control infrastructure** (laptop, gamepad, wireless link)
+- **External power** (battery, charger)
+
+The rover is expected to be **assembled by non-specialists** from commercially available parts, **operated remotely** via a ground station, and **extended** with custom sensors or payloads.
+
+## Operational Architecture Block (OAB) Summary
+
+```
+┌──────────────────────────────────────────────────────┐
+│                 Operational Environment               │
+│                                                      │
+│  [Operator] ──control──► [OSR System]                │
+│      │                       │                       │
+│      │◄──telemetry────────────┤                       │
+│                               │                      │
+│  [Builder] ──assembly──► [OSR Hardware]              │
+│                                                      │
+│  [Developer] ──software──► [OSR Software Stack]      │
+│                                                      │
+│  [Terrain] ◄──traversal── [OSR Mobility]             │
+└──────────────────────────────────────────────────────┘
+```
+
+## Traceability
+
+Operational Activities in this layer are realized by **System Functions** in the [System Analysis](../02_system_analysis/README.md).

--- a/systems_engineering/01_operational_analysis/operational_activities.md
+++ b/systems_engineering/01_operational_analysis/operational_activities.md
@@ -1,0 +1,151 @@
+# Operational Activities
+
+**OA Layer — Operational Activity Register**
+
+Operational Activities (OActs) describe **what must be done** in the operational world — independent of how the system does it. Each activity is owned by an Operational Entity and may exchange data or artifacts with other activities.
+
+## Activity Hierarchy
+
+```
+Root Operational Activity (OAct-00)
+├── OAct-01  Conduct Rover Mission
+│   ├── OAct-01.1  Plan Traverse Route
+│   ├── OAct-01.2  Command Rover Motion
+│   ├── OAct-01.3  Monitor Rover State
+│   ├── OAct-01.4  Respond to Hazard
+│   └── OAct-01.5  Collect Sensor Data
+├── OAct-02  Maintain Rover
+│   ├── OAct-02.1  Charge Battery
+│   ├── OAct-02.2  Inspect and Repair Hardware
+│   └── OAct-02.3  Update Software
+├── OAct-03  Build Rover
+│   ├── OAct-03.1  Source Components
+│   ├── OAct-03.2  Assemble Mechanical Structure
+│   ├── OAct-03.3  Install Electrical System
+│   └── OAct-03.4  Install and Configure Software
+└── OAct-04  Extend Rover Capability
+    ├── OAct-04.1  Design Payload or Modification
+    ├── OAct-04.2  Integrate Payload
+    └── OAct-04.3  Develop Custom Software
+```
+
+## Activity Descriptions
+
+### OAct-01 — Conduct Rover Mission
+
+The core operational scenario: a human operator directs the rover through a terrain environment to accomplish a task (traverse, exploration, demonstration, data collection).
+
+#### OAct-01.1 — Plan Traverse Route
+- **Owner:** Ground Operator
+- **Inputs:** Terrain knowledge, mission objectives
+- **Outputs:** Planned waypoints, go/no-go decision
+- **Description:** Operator assesses terrain ahead of the rover and determines a path to traverse, avoiding obstacles that exceed the rover's mobility limits.
+
+#### OAct-01.2 — Command Rover Motion
+- **Owner:** Ground Operator → Ground Station → OSR System
+- **Inputs:** Operator intent (gamepad axes/buttons)
+- **Outputs:** Motion commands (velocity, steering angle)
+- **Description:** Operator translates intended motion into commands. Ground station encodes and transmits these. The rover executes the commanded motion.
+
+#### OAct-01.3 — Monitor Rover State
+- **Owner:** Ground Operator
+- **Inputs:** Telemetry from rover (battery voltage, motor currents, wheel speeds, IMU orientation)
+- **Outputs:** Situational awareness, fault recognition
+- **Description:** Operator continuously monitors rover health and position during the mission, watching for faults, battery depletion, or mechanical issues.
+
+#### OAct-01.4 — Respond to Hazard
+- **Owner:** Ground Operator
+- **Inputs:** Hazard detection (visual inspection or telemetry anomaly)
+- **Outputs:** Corrective commands (stop, reverse, new route)
+- **Description:** When the operator detects a hazard (stuck wheel, tip risk, low battery), they take corrective action to protect the rover.
+
+#### OAct-01.5 — Collect Sensor Data
+- **Owner:** Ground Operator / Developer
+- **Inputs:** Camera stream, optional payload sensor outputs
+- **Outputs:** Recorded images, data logs
+- **Description:** Operator captures data from onboard sensors during the traverse.
+
+---
+
+### OAct-02 — Maintain Rover
+
+#### OAct-02.1 — Charge Battery
+- **Owner:** Builder / Operator
+- **Inputs:** Depleted battery pack
+- **Outputs:** Charged battery, restored operational capacity
+- **Description:** Remove or connect battery to charger; monitor charging state.
+
+#### OAct-02.2 — Inspect and Repair Hardware
+- **Owner:** Builder
+- **Inputs:** Mechanical fault observation
+- **Outputs:** Repaired assembly, replaced components
+- **Description:** Inspect joints, fasteners, wheels, and wiring after operation; replace worn or damaged parts.
+
+#### OAct-02.3 — Update Software
+- **Owner:** Developer
+- **Inputs:** New software version or bug fix
+- **Outputs:** Updated rover firmware/software
+- **Description:** Developer connects to the rover's onboard computer and deploys updated software packages.
+
+---
+
+### OAct-03 — Build Rover
+
+#### OAct-03.1 — Source Components
+- **Owner:** Builder
+- **Inputs:** Parts list, budget
+- **Outputs:** Procured parts kit
+- **Description:** Builder orders mechanical hardware, electronics, motors, and compute components from suppliers.
+
+#### OAct-03.2 — Assemble Mechanical Structure
+- **Owner:** Builder
+- **Inputs:** Procured parts, assembly instructions
+- **Outputs:** Assembled chassis with rocker-bogie suspension and wheels
+- **Description:** Builder follows step-by-step instructions to assemble the frame, rocker-bogie linkage, corner steering assemblies, and six wheel modules.
+
+#### OAct-03.3 — Install Electrical System
+- **Owner:** Builder
+- **Inputs:** Electronics kit, wiring diagrams
+- **Outputs:** Wired and powered electrical system
+- **Description:** Builder installs PCB, motors, motor drivers, and power distribution; performs wiring per schematic.
+
+#### OAct-03.4 — Install and Configure Software
+- **Owner:** Developer / Builder
+- **Inputs:** Software repository, Raspberry Pi
+- **Outputs:** Operational rover with running software
+- **Description:** Flash OS, clone software repo, configure network and ROS environment, test communication with ground station.
+
+---
+
+### OAct-04 — Extend Rover Capability
+
+#### OAct-04.1 — Design Payload or Modification
+- **Owner:** Developer / Engineer Contributor
+- **Inputs:** Extension requirements, rover interface specs
+- **Outputs:** Payload design (mechanical + electrical + software)
+
+#### OAct-04.2 — Integrate Payload
+- **Owner:** Builder
+- **Inputs:** Payload hardware, rover mounting points
+- **Outputs:** Rover with integrated payload
+
+#### OAct-04.3 — Develop Custom Software
+- **Owner:** Developer
+- **Inputs:** Payload data interface, ROS APIs
+- **Outputs:** Custom ROS nodes, behaviors, or autonomy modules
+
+## Operational Scenario: Nominal Mission
+
+```
+Operator powers on rover
+    └──► Rover boots, establishes wireless link
+Operator verifies link via Ground Station
+    └──► Telemetry stream confirmed
+Operator commands forward motion
+    └──► Rover traverses 2 m over flat surface
+Operator commands left turn
+    └──► Rover pivots 45°
+Operator detects low battery warning
+    └──► Operator commands stop and returns rover to start
+Operator disconnects power and charges battery
+```

--- a/systems_engineering/01_operational_analysis/operational_capabilities.md
+++ b/systems_engineering/01_operational_analysis/operational_capabilities.md
@@ -1,0 +1,46 @@
+# Operational Capabilities
+
+**OA Layer — Operational Capability Register**
+
+Operational Capabilities describe **high-level abilities** the operational environment must provide, independent of how they are achieved. They are the coarsest-grained expression of what the OSR program must enable.
+
+## Capability Register
+
+| ID | Capability | Description |
+|---|---|---|
+| OC-01 | **Terrain Mobility** | The ability to traverse a variety of surface types including flat floors, carpet, gravel, and moderate inclines |
+| OC-02 | **Remote Control** | The ability for a human operator to command rover motion from a safe distance via wireless link |
+| OC-03 | **State Monitoring** | The ability to observe rover health, position, and sensor data in real time at the ground station |
+| OC-04 | **Safe Operation** | The ability to detect and respond to hazardous conditions (e.g., tip risk, low battery, motor fault) |
+| OC-05 | **Build and Assembly** | The ability for a non-specialist to assemble the rover from available commercial parts |
+| OC-06 | **Software Programmability** | The ability for a developer to write, deploy, and modify rover software |
+| OC-07 | **Payload Integration** | The ability to attach optional sensors, cameras, or actuators and integrate them into the rover data stream |
+| OC-08 | **Educational Fidelity** | The ability to serve as a credible analog of Mars rovers for STEM education |
+
+## Capability Scenario Matrix
+
+Each capability is exercised in one or more operational scenarios:
+
+| Scenario | OC-01 | OC-02 | OC-03 | OC-04 | OC-05 | OC-06 | OC-07 | OC-08 |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Nominal terrain traverse | ● | ● | ● | ● | | | | ● |
+| Hazard avoidance | ● | ● | ● | ● | | | | |
+| Initial build and test | | | ● | | ● | ● | | |
+| Payload demonstration | ● | ● | ● | | | ● | ● | ● |
+| Software development/debug | | | ● | | | ● | | |
+| Classroom demonstration | ● | ● | ● | ● | | | | ● |
+
+## Traceability to System Capabilities
+
+Operational Capabilities are refined into **System Capabilities** in the [System Analysis](../02_system_analysis/capabilities.md) layer:
+
+| OC ID | Realized by System Capability |
+|---|---|
+| OC-01 | SC-01 Six-Wheel Drive Mobility, SC-02 Rocker-Bogie Passive Suspension |
+| OC-02 | SC-03 Wireless Command Reception, SC-04 Motor Control Execution |
+| OC-03 | SC-05 Telemetry Reporting |
+| OC-04 | SC-06 Fault Detection and Safe Stop |
+| OC-05 | SC-07 Modular Assembly Architecture |
+| OC-06 | SC-08 Programmable Onboard Computer |
+| OC-07 | SC-09 Payload Interface |
+| OC-08 | SC-01, SC-02 (rocker-bogie is the key fidelity element) |

--- a/systems_engineering/01_operational_analysis/operational_entities.md
+++ b/systems_engineering/01_operational_analysis/operational_entities.md
@@ -1,0 +1,90 @@
+# Operational Entities
+
+**OA Layer — Operational Entity Register**
+
+Operational Entities (OEs) are the actors and external systems that participate in the operational environment. They interact with each other and with the OSR system through **operational interactions**.
+
+## Entity Register
+
+| ID | Entity | Type | Description |
+|---|---|---|---|
+| OE-01 | **Ground Operator** | Human Actor | Person controlling the rover via ground station |
+| OE-02 | **Ground Station** | External System | Laptop/computer running operator control software |
+| OE-03 | **Wireless Link** | External System | Wi-Fi or other RF link between ground station and rover |
+| OE-04 | **OSR System** | System-of-Interest | The rover itself (treated as a black box at this layer) |
+| OE-05 | **Terrain** | Environment | The surface the rover traverses — floors, gravel, obstacles |
+| OE-06 | **Power Source** | External System | Battery pack supplying electrical energy to the rover |
+| OE-07 | **Builder** | Human Actor | Person assembling the rover from parts |
+| OE-08 | **Parts Suppliers** | External System | Vendors supplying mechanical, electrical, and electronic components |
+| OE-09 | **Developer** | Human Actor | Person writing or modifying rover software |
+| OE-10 | **Payload / Sensor** | External System | Optional extensions (cameras, arms, science instruments) |
+
+## Operational Interactions
+
+### Primary Control Loop
+
+```
+[Ground Operator]
+      │
+      │ issues motion commands (gamepad input)
+      ▼
+[Ground Station]
+      │
+      │ encodes commands (ROS messages / serial packets)
+      ▼
+[Wireless Link]
+      │
+      │ transmits over Wi-Fi
+      ▼
+[OSR System]
+      │
+      │ executes motion
+      ▼
+[Terrain] ◄── rover exerts forces
+      │
+      │ rover state (odometry, attitude)
+      ▼
+[OSR System]
+      │
+      │ telemetry data
+      ▼
+[Wireless Link] → [Ground Station] → [Ground Operator]
+```
+
+### Power Loop
+
+```
+[Power Source] ──DC power──► [OSR System]
+[OSR System] ──discharge status──► [Ground Operator]
+```
+
+### Build Loop
+
+```
+[Builder] ──assembly work──► [OSR System]
+[Parts Suppliers] ──components──► [Builder]
+[Developer] ──software install──► [OSR System]
+```
+
+### Payload Extension Loop
+
+```
+[Payload / Sensor] ──data──► [OSR System]
+[OSR System] ──power + comms──► [Payload / Sensor]
+[OSR System] ──sensor telemetry──► [Ground Station]
+```
+
+## Entity Roles
+
+| Entity | Provides | Receives |
+|---|---|---|
+| OE-01 Ground Operator | Control intent | Rover telemetry, camera video |
+| OE-02 Ground Station | Encoded commands | Telemetry, video stream |
+| OE-03 Wireless Link | Bidirectional data channel | Commands (downlink), telemetry (uplink) |
+| OE-04 OSR System | Motion, sensor data | Commands, power |
+| OE-05 Terrain | Reaction forces, obstacles | Rover wheel forces |
+| OE-06 Power Source | Electrical energy | — |
+| OE-07 Builder | Assembled hardware | Parts, documentation |
+| OE-08 Parts Suppliers | Components | Purchase orders |
+| OE-09 Developer | Software | Hardware platform |
+| OE-10 Payload / Sensor | Sensor data | Power, communication interface |

--- a/systems_engineering/01_operational_analysis/stakeholders.md
+++ b/systems_engineering/01_operational_analysis/stakeholders.md
@@ -1,0 +1,72 @@
+# Stakeholders
+
+**OA Layer — Stakeholder Register**
+
+Stakeholders are all parties whose interests must be considered in the design and operation of the OSR. Each stakeholder has needs that drive system requirements.
+
+## Stakeholder Table
+
+| ID | Stakeholder | Role | Primary Interests |
+|---|---|---|---|
+| SH-01 | **Rover Operator** | Remotely controls rover during missions | Reliable control, responsive telemetry, intuitive interface |
+| SH-02 | **Builder / Assembler** | Constructs rover from kit or sourced parts | Clear instructions, standard hardware, low assembly complexity |
+| SH-03 | **Software Developer** | Writes or modifies rover code | Documented APIs, modular software, open-source stack |
+| SH-04 | **Educator / Instructor** | Uses rover in classroom or camp setting | Durability, safety, educational value, curriculum alignment |
+| SH-05 | **Student / Learner** | Learns STEM concepts through rover | Engagement, approachability, hands-on interaction |
+| SH-06 | **Mechanical Engineer (Contributor)** | Designs or modifies mechanical systems | CAD availability, modularity, standard hardware |
+| SH-07 | **Electrical Engineer (Contributor)** | Designs or modifies electrical systems | PCB accessibility, documented schematics, safety |
+| SH-08 | **Open-Source Community** | Uses, modifies, and extends the platform | Permissive license, documentation quality, issue tracking |
+| SH-09 | **JPL / NASA** | Maintains project and ensures fidelity to real rovers | Technical accuracy, brand alignment, outreach value |
+| SH-10 | **Terrain / Environment** | The physical world the rover operates in | (Constraint stakeholder — imposes physical demands) |
+
+## Stakeholder Needs
+
+### SH-01 — Rover Operator
+
+| Need ID | Need Statement |
+|---|---|
+| N-SH01-01 | The operator shall be able to command rover motion (forward, reverse, turn, stop) via a wireless interface |
+| N-SH01-02 | The operator shall receive real-time feedback on rover state (orientation, battery, fault status) |
+| N-SH01-03 | The operator shall be able to stop all rover motion within 1 second of issuing a stop command |
+| N-SH01-04 | The operator shall be able to control the rover from at least 10 meters distance |
+
+### SH-02 — Builder / Assembler
+
+| Need ID | Need Statement |
+|---|---|
+| N-SH02-01 | All structural components shall be sourceable from standard commercial suppliers |
+| N-SH02-02 | Assembly shall be accomplishable with standard hand tools (no CNC or specialized equipment required beyond optional 3D printing) |
+| N-SH02-03 | Assembly instructions shall include step-by-step guidance with photographs |
+| N-SH02-04 | Total build cost shall remain under $2,500 USD |
+
+### SH-03 — Software Developer
+
+| Need ID | Need Statement |
+|---|---|
+| N-SH03-01 | Software shall run on a standard single-board computer (Raspberry Pi) |
+| N-SH03-02 | All rover software shall be open-source and version-controlled |
+| N-SH03-03 | Control interfaces shall support ROS (Robot Operating System) |
+| N-SH03-04 | Motor control APIs shall be documented and accessible |
+
+### SH-04 — Educator / Instructor
+
+| Need ID | Need Statement |
+|---|---|
+| N-SH04-01 | The rover shall be operable by students aged 14+ without specialist knowledge |
+| N-SH04-02 | The rover shall not pose electrical or mechanical safety hazards under normal operation |
+| N-SH04-03 | The system shall support curriculum on robotics, programming, and planetary science |
+
+### SH-05 — Student / Learner
+
+| Need ID | Need Statement |
+|---|---|
+| N-SH05-01 | The rover shall be visually recognizable as analogous to Mars exploration rovers |
+| N-SH05-02 | Students shall be able to write and deploy their own code to the rover |
+
+### SH-09 — JPL / NASA
+
+| Need ID | Need Statement |
+|---|---|
+| N-SH09-01 | The rover suspension shall implement the rocker-bogie mechanism as used on real Mars rovers |
+| N-SH09-02 | The rover shall use a six-wheel drive configuration |
+| N-SH09-03 | Documentation and branding shall acknowledge JPL/Caltech origin |

--- a/systems_engineering/02_system_analysis/README.md
+++ b/systems_engineering/02_system_analysis/README.md
@@ -1,0 +1,74 @@
+# System Analysis (SA)
+
+**Arcadia Layer 2 of 5**
+
+The System Analysis answers the question: **WHAT must the system do?** It establishes the system boundary — what is inside the OSR versus what is external — and defines the functions, capabilities, and interfaces the system must provide to satisfy operational needs.
+
+## Purpose
+
+The SA translates operational activities and capabilities into **system functions** and **system capabilities**. It defines what the OSR does, without yet deciding how it does it internally.
+
+## Documents
+
+| Document | Contents |
+|---|---|
+| [System Functions](system_functions.md) | Functions the system must perform |
+| [Capabilities](capabilities.md) | System-level capabilities |
+| [Missions](missions.md) | Mission scenarios and use cases |
+| [Interfaces](interfaces.md) | External interfaces at the system boundary |
+
+## System Boundary
+
+The OSR system boundary separates the rover (system-of-interest) from external elements:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        OSR SYSTEM BOUNDARY                        │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                    OSR System                             │   │
+│  │                                                          │   │
+│  │  [Mobility]  [Power Mgmt]  [Compute]  [Comms]  [Sensing] │  │
+│  └──────────────────────────────────────────────────────────┘   │
+│        ▲              ▲           ▲          ▲          │        │
+│        │              │           │          │          │        │
+└────────┼──────────────┼───────────┼──────────┼──────────┼────────┘
+         │              │           │          │          │
+    [Terrain]   [Battery/Power]  [Operator] [Ground Stn] [Env]
+```
+
+**Inside the boundary:** drive motors, motor controllers, PCB, Raspberry Pi, onboard camera, chassis, wheels, rocker-bogie suspension, IMU, battery monitoring circuitry.
+
+**Outside the boundary:** battery pack (external power source), ground station laptop, gamepad controller, wireless router/infrastructure, terrain, payloads (optional external attachments).
+
+## System Context (State Machine Summary)
+
+The OSR System operates in the following high-level states:
+
+```
+         ┌──────────┐
+    ──►  │  OFF     │
+         └────┬─────┘
+              │ power on
+         ┌────▼─────┐
+         │  BOOTING │
+         └────┬─────┘
+              │ boot complete + link established
+         ┌────▼──────────┐
+         │  STANDBY      │◄──────────────┐
+         └────┬──────────┘               │
+              │ motion command           │ stop command / fault clear
+         ┌────▼──────────┐              │
+         │  EXECUTING    ├──────────────┘
+         └────┬──────────┘
+              │ fault detected
+         ┌────▼──────────┐
+         │  SAFE STOP    │
+         └───────────────┘
+```
+
+## Traceability
+
+- System Functions realize **Operational Activities** from [OA layer](../01_operational_analysis/operational_activities.md)
+- System Capabilities realize **Operational Capabilities** from [OA layer](../01_operational_analysis/operational_capabilities.md)
+- System components are realized by **Logical Components** in [LA layer](../03_logical_architecture/README.md)

--- a/systems_engineering/02_system_analysis/capabilities.md
+++ b/systems_engineering/02_system_analysis/capabilities.md
@@ -1,0 +1,83 @@
+# System Capabilities
+
+**SA Layer — System Capability Register**
+
+System Capabilities (SCs) define the **high-level abilities** the OSR system must possess. They are realized by combinations of System Functions and system components.
+
+## Capability Register
+
+| ID | Capability | Description | Realizes OC |
+|---|---|---|---|
+| SC-01 | **Six-Wheel Drive Mobility** | The system shall drive all six wheels simultaneously, providing redundant traction on uneven terrain | OC-01 |
+| SC-02 | **Rocker-Bogie Passive Suspension** | The system shall maintain continuous ground contact for all six wheels over obstacles up to wheel-diameter height | OC-01, OC-08 |
+| SC-03 | **Wireless Command Reception** | The system shall receive motion commands wirelessly from a ground station over Wi-Fi | OC-02 |
+| SC-04 | **Motor Control Execution** | The system shall translate received commands into motor PWM signals within 100 ms | OC-02 |
+| SC-05 | **Telemetry Reporting** | The system shall transmit rover state (battery, orientation, speeds, faults) to the ground station at ≥ 5 Hz | OC-03 |
+| SC-06 | **Fault Detection and Safe Stop** | The system shall detect overcurrent, low battery, and excessive tilt; execute a safe stop autonomously | OC-04 |
+| SC-07 | **Modular Assembly Architecture** | The system shall be assembled from bolt-together subassemblies without permanent joining (no welding) | OC-05 |
+| SC-08 | **Programmable Onboard Computer** | The system shall host a general-purpose Linux computer accessible via SSH for software deployment | OC-06 |
+| SC-09 | **Payload Interface** | The system shall expose switched power (5V, 12V) and a data bus (USB, I²C) for optional payloads | OC-07 |
+
+## Capability Specifications
+
+### SC-01 — Six-Wheel Drive Mobility
+
+| Parameter | Requirement |
+|---|---|
+| Number of driven wheels | 6 |
+| Drive motor type | DC brushed motor with encoder (e.g., Nidec/Hurst) |
+| Maximum speed (flat ground) | ≥ 0.3 m/s |
+| Minimum speed (controlled) | ≤ 0.05 m/s |
+| Ground clearance | ≥ 100 mm |
+| Maximum slope traversal | ≥ 20° incline |
+
+### SC-02 — Rocker-Bogie Passive Suspension
+
+| Parameter | Requirement |
+|---|---|
+| Suspension type | Passive rocker-bogie (no active actuation) |
+| Maximum obstacle height | ≥ wheel radius (approximately 75 mm) |
+| Wheel contact maintained | All 6 wheels, on surfaces up to ±30° individual wheel tilt |
+| Mechanism fidelity | Mechanically equivalent to JPL Mars rover suspension topology |
+
+### SC-03 — Wireless Command Reception
+
+| Parameter | Requirement |
+|---|---|
+| Protocol | Wi-Fi 802.11 b/g/n |
+| Command latency | ≤ 200 ms round trip (local network) |
+| Operating range | ≥ 10 m (line of sight, indoor) |
+| Command watchdog | Stop motors if no valid command in > 1.0 s |
+
+### SC-04 — Motor Control Execution
+
+| Parameter | Requirement |
+|---|---|
+| Command-to-motor latency | ≤ 100 ms |
+| Steering corner response | ≤ 500 ms to reach target angle |
+| PWM update rate | ≥ 20 Hz |
+
+### SC-05 — Telemetry Reporting
+
+| Parameter | Requirement |
+|---|---|
+| Telemetry rate | ≥ 5 Hz |
+| Fields | Battery voltage %, motor currents, wheel speeds, IMU attitude, fault flags |
+| Protocol | ROS topics over Wi-Fi |
+
+### SC-06 — Fault Detection and Safe Stop
+
+| Parameter | Requirement |
+|---|---|
+| Overcurrent threshold | Motor current > 10 A (per motor) |
+| Low battery threshold | Battery voltage < 10.5 V (3S LiPo) |
+| Tilt threshold | Roll or pitch > 35° |
+| Safe stop response time | ≤ 200 ms after fault detection |
+
+### SC-09 — Payload Interface
+
+| Parameter | Requirement |
+|---|---|
+| Power outputs | 5V @ 2A (logic/sensor), 12V @ 3A (actuators) |
+| Data interfaces | USB 2.0 ×2, I²C ×1, UART ×1 |
+| Mechanical mounting | Standard M3 bolt pattern on body plate |

--- a/systems_engineering/02_system_analysis/interfaces.md
+++ b/systems_engineering/02_system_analysis/interfaces.md
@@ -1,0 +1,138 @@
+# System Interfaces
+
+**SA Layer — System Interface Register**
+
+System Interfaces define all connections between the OSR system and external entities at the system boundary. Each interface has a defined protocol, media, and data/power content.
+
+## Interface Register
+
+| ID | Interface | Direction | Connected Entity | Medium | Protocol/Standard |
+|---|---|---|---|---|---|
+| IF-01 | Command Input | IN | Ground Station | Wi-Fi 802.11 | ROS (UDP/TCP) |
+| IF-02 | Telemetry Output | OUT | Ground Station | Wi-Fi 802.11 | ROS (UDP/TCP) |
+| IF-03 | Video Output | OUT | Ground Station | Wi-Fi 802.11 | MJPEG / H.264 |
+| IF-04 | Battery Power Input | IN | Battery Pack | DC wire | 11.1V 3S LiPo |
+| IF-05 | Payload Power Output | OUT | Payload | DC wire | 5V / 12V regulated |
+| IF-06 | Payload Data | BIDIR | Payload | USB / I²C / UART | Device-specific |
+| IF-07 | Developer Access | BIDIR | Developer Laptop | Wi-Fi 802.11 | SSH / SCP |
+| IF-08 | Physical Terrain | BIDIR | Terrain | Mechanical (wheel contact) | Force/reaction |
+
+---
+
+## Interface Specifications
+
+### IF-01 — Command Input
+
+| Attribute | Value |
+|---|---|
+| Physical medium | Wi-Fi 802.11 b/g/n (2.4 GHz) |
+| Protocol | ROS `geometry_msgs/Twist` topic |
+| Topic name | `/cmd_vel` |
+| Data rate | ≥ 10 Hz command updates |
+| Latency budget | ≤ 100 ms network latency |
+| Encoding | ROS serialization (binary) |
+| Watchdog | Motor stop if no message in 1.0 s |
+
+**Message format (`geometry_msgs/Twist`):**
+```
+linear:
+  x: [m/s]   # forward/backward velocity
+  y: 0.0     # unused
+  z: 0.0     # unused
+angular:
+  x: 0.0     # unused
+  y: 0.0     # unused
+  z: [rad/s] # turning rate
+```
+
+---
+
+### IF-02 — Telemetry Output
+
+| Attribute | Value |
+|---|---|
+| Physical medium | Wi-Fi 802.11 b/g/n |
+| Protocol | ROS topics |
+| Update rate | ≥ 5 Hz |
+| Topics published | See below |
+
+**Published topics:**
+
+| Topic | Message Type | Content |
+|---|---|---|
+| `/battery_state` | `sensor_msgs/BatteryState` | Voltage, current, percentage |
+| `/imu` | `sensor_msgs/Imu` | Orientation, angular velocity, linear accel |
+| `/odom` | `nav_msgs/Odometry` | Estimated position and velocity |
+| `/wheel_speeds` | `std_msgs/Float32MultiArray` | Per-wheel RPM (6 values) |
+| `/motor_currents` | `std_msgs/Float32MultiArray` | Per-motor current draw (A) |
+| `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | Fault flags and system health |
+
+---
+
+### IF-03 — Video Output
+
+| Attribute | Value |
+|---|---|
+| Physical medium | Wi-Fi 802.11 b/g/n |
+| Protocol | HTTP MJPEG stream or ROS `sensor_msgs/Image` |
+| Resolution | 640×480 minimum; 1280×720 preferred |
+| Frame rate | ≥ 10 fps |
+| Camera | Raspberry Pi Camera Module (or USB camera) |
+
+---
+
+### IF-04 — Battery Power Input
+
+| Attribute | Value |
+|---|---|
+| Physical connector | XT60 or Dean's T-plug |
+| Nominal voltage | 11.1 V (3S LiPo) |
+| Maximum discharge rate | ≥ 20C (continuous) |
+| Capacity | ≥ 5000 mAh |
+| Cutoff voltage | 9.0 V (hardware) / 10.5 V (software warning) |
+| Maximum current draw | ≤ 20 A (all motors stalled simultaneously) |
+
+---
+
+### IF-05 — Payload Power Output
+
+| Attribute | Value |
+|---|---|
+| 5V rail | ≤ 2 A continuous |
+| 12V rail | ≤ 3 A continuous (unswitched from battery via regulator) |
+| Connector type | JST-PH 2-pin or screw terminal |
+| Protection | Polyfuse or resettable fuse |
+
+---
+
+### IF-06 — Payload Data
+
+| Attribute | Value |
+|---|---|
+| USB | USB 2.0 Type-A ×2 (from Raspberry Pi) |
+| I²C | 3.3V logic, 400 kHz fast mode |
+| UART | 3.3V logic, up to 115200 baud |
+| SPI | Optional; routed to GPIO header |
+
+---
+
+### IF-07 — Developer Access
+
+| Attribute | Value |
+|---|---|
+| Protocol | SSH (port 22), SCP |
+| Authentication | SSH key or password |
+| Network | Same Wi-Fi subnet as rover |
+| Hostname | `rover.local` (mDNS) or static IP |
+
+---
+
+### IF-08 — Physical Terrain Interface
+
+| Attribute | Value |
+|---|---|
+| Interface type | Mechanical — wheel-ground contact |
+| Wheel material | Rubber or printed TPU tire |
+| Contact area per wheel | Approximately 30 mm × 20 mm |
+| Maximum normal force per wheel | ~2.5 kg (total rover mass ~7 kg, ~1.2 kg/wheel average) |
+| Terrain traction requirement | μ ≥ 0.4 (minimum friction coefficient for commanded motion) |

--- a/systems_engineering/02_system_analysis/missions.md
+++ b/systems_engineering/02_system_analysis/missions.md
@@ -1,0 +1,171 @@
+# Missions and Use Cases
+
+**SA Layer — Mission Register**
+
+Missions define the operational scenarios that the OSR system must support. Each mission describes the context, actors, preconditions, scenario flow, and success criteria.
+
+## Mission Register
+
+| ID | Mission | Primary Stakeholders | Frequency |
+|---|---|---|---|
+| M-01 | Nominal Terrain Traverse | Operator, Educator, Student | High |
+| M-02 | Obstacle Negotiation | Operator | Medium |
+| M-03 | Fault Recovery | Operator | Low |
+| M-04 | Software Development and Test | Developer | High |
+| M-05 | Classroom Demonstration | Educator, Student | High |
+| M-06 | Payload Operation | Developer, Researcher | Low |
+| M-07 | Build and Bring-Up | Builder | One-time per unit |
+
+---
+
+## M-01 — Nominal Terrain Traverse
+
+**Scenario:** Operator drives the rover across a prepared surface (lab floor, gym, outdoor path) using a gamepad.
+
+**Preconditions:**
+- Rover is powered on and fully booted
+- Ground station is connected and receiving telemetry
+- Battery charge ≥ 50%
+
+**Scenario Flow:**
+1. Operator powers on rover; waits for boot (~30 s)
+2. Operator launches ground station software
+3. Ground station confirms telemetry stream (battery, orientation)
+4. Operator commands forward motion with gamepad
+5. Rover accelerates to commanded speed
+6. Operator steers rover left/right to avoid obstacles
+7. Operator monitors telemetry during traverse
+8. Operator commands stop; rover decelerates to rest
+9. Operator powers off rover; connects battery to charger
+
+**Success Criteria:**
+- Rover follows operator commands with ≤ 200 ms latency
+- No wheel slip or stall on flat surface
+- Telemetry updates continuously at ≥ 5 Hz
+- Battery depletes predictably; low-battery warning displayed before cutoff
+
+---
+
+## M-02 — Obstacle Negotiation
+
+**Scenario:** Rover traverses a surface with discrete obstacles (books, wooden blocks) up to ~75 mm height.
+
+**Preconditions:** Same as M-01
+
+**Scenario Flow:**
+1. Operator positions rover 0.5 m from obstacle
+2. Operator commands slow forward motion (< 0.1 m/s)
+3. Lead wheels contact obstacle and begin to climb
+4. Rocker-bogie suspension articulates passively — other wheels maintain ground contact
+5. Rover crests obstacle; suspension returns to nominal
+6. Operator continues traverse on far side of obstacle
+
+**Success Criteria:**
+- All six wheels maintain ground contact throughout
+- Rover does not tip or lose traction
+- No operator intervention required (passive suspension handles articulation)
+
+---
+
+## M-03 — Fault Recovery
+
+**Scenario:** A motor stall or low-battery condition triggers the system safe stop.
+
+**Scenario Flow:**
+1. Rover is executing M-01 traverse
+2. A wheel jams on an obstacle causing motor overcurrent
+3. SF-06 Fault Detection triggers safe stop (all motors to zero)
+4. Telemetry displays fault flag to operator
+5. Operator acknowledges fault via ground station
+6. Operator reverses rover slowly to free jammed wheel
+7. Operator clears fault flag; rover returns to STANDBY state
+
+**Success Criteria:**
+- Safe stop occurs within 200 ms of fault detection
+- Fault flag is visible on ground station within one telemetry cycle
+- System recovers to STANDBY after operator acknowledgment
+
+---
+
+## M-04 — Software Development and Test
+
+**Scenario:** Developer connects to rover over SSH and deploys new ROS node.
+
+**Preconditions:**
+- Rover on same Wi-Fi network as development laptop
+- Rover is in STANDBY state
+
+**Scenario Flow:**
+1. Developer SSHs into Raspberry Pi (`ssh pi@rover.local`)
+2. Developer pulls updated code from git repository
+3. Developer builds and installs new ROS package (`catkin_make install`)
+4. Developer launches new node and observes ROS topic output
+5. Developer commands test motion and verifies new behavior
+6. Developer commits and pushes changes
+
+**Success Criteria:**
+- SSH accessible without physical connection
+- ROS build completes without errors
+- New node subscribes/publishes on expected topics
+
+---
+
+## M-05 — Classroom Demonstration
+
+**Scenario:** Educator demonstrates rover to students; students take turns operating.
+
+**Preconditions:**
+- Rover pre-configured and tested
+- Clear area ≥ 4m × 4m available
+- Ground station laptop set up and connected
+
+**Scenario Flow:**
+1. Educator powers on rover and confirms operation
+2. Student 1 takes gamepad and drives rover forward/backward
+3. Student 2 drives rover in a square path
+4. Educator shows telemetry display explaining battery, motors, and IMU
+5. Educator powers off rover
+
+**Success Criteria:**
+- No hardware damage during student operation
+- All students successfully control rover within 2 minutes of instructions
+- Telemetry display accessible to whole class
+
+---
+
+## M-06 — Payload Operation
+
+**Scenario:** Developer installs a custom sensor (e.g., LIDAR, moisture sensor) and collects data during traverse.
+
+**Scenario Flow:**
+1. Builder mounts sensor to body plate using M3 bolt pattern
+2. Developer connects sensor to USB or I²C interface
+3. Developer installs ROS driver node for sensor
+4. Operator drives rover while developer monitors sensor topic
+5. Data is logged to disk for analysis
+
+**Success Criteria:**
+- Payload power supplied without voltage drop affecting drive motors
+- Sensor data available on ROS topic at specified rate
+- No interference between payload data and drive control
+
+---
+
+## M-07 — Build and Bring-Up
+
+**Scenario:** Builder assembles rover from parts following documentation.
+
+**Key Milestones:**
+
+| Milestone | Description |
+|---|---|
+| M-07.1 | Mechanical assembly complete — chassis, rocker-bogie, wheels |
+| M-07.2 | Electrical installation complete — PCB, motors, wiring |
+| M-07.3 | Software installed — OS flashed, ROS configured |
+| M-07.4 | First motion test — all 6 wheels drive on command |
+| M-07.5 | Full integration test — telemetry, video, fault detection verified |
+
+**Success Criteria:**
+- Build completable by one person in ≤ 40 hours
+- All M-07 milestones achievable without specialized equipment
+- Rover passes M-01 scenario after M-07.5

--- a/systems_engineering/02_system_analysis/system_functions.md
+++ b/systems_engineering/02_system_analysis/system_functions.md
@@ -1,0 +1,160 @@
+# System Functions
+
+**SA Layer — System Function Register**
+
+System Functions (SFs) define **what the OSR system does** at its boundary. Each SF receives inputs from outside and produces outputs that go outside the system, or internally transforms state to enable other functions. Functions are decomposed hierarchically from a root.
+
+## Function Hierarchy
+
+```
+Root System Function (SF-00)
+├── SF-01  Receive and Decode Command
+├── SF-02  Execute Mobility
+│   ├── SF-02.1  Compute Drive Commands
+│   ├── SF-02.2  Drive Wheels
+│   └── SF-02.3  Steer Corner Wheels
+├── SF-03  Manage Power
+│   ├── SF-03.1  Distribute Electrical Power
+│   ├── SF-03.2  Monitor Battery State
+│   └── SF-03.3  Protect Against Overcurrent/Short
+├── SF-04  Process and Publish Telemetry
+│   ├── SF-04.1  Sample Sensors
+│   ├── SF-04.2  Estimate Rover State
+│   └── SF-04.3  Transmit Telemetry
+├── SF-05  Capture and Stream Video
+├── SF-06  Detect and Handle Faults
+│   ├── SF-06.1  Monitor Motor Currents
+│   ├── SF-06.2  Monitor Battery Voltage
+│   ├── SF-06.3  Detect Tip Risk (IMU)
+│   └── SF-06.4  Execute Safe Stop
+└── SF-07  Support Payload Interface
+    ├── SF-07.1  Provide Power to Payload
+    └── SF-07.2  Route Payload Data
+```
+
+## Function Descriptions
+
+### SF-01 — Receive and Decode Command
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Encoded command packet (Wi-Fi / serial) |
+| **Outputs** | Decoded motion intent (linear velocity, angular velocity) |
+| **Realizes** | OAct-01.2 Command Rover Motion |
+| **Notes** | Handles ROS topic subscription; validates packet integrity; applies watchdog timeout (stop if no command received within 1 s) |
+
+---
+
+### SF-02 — Execute Mobility
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Decoded motion intent |
+| **Outputs** | Motor PWM signals, wheel rotation |
+| **Realizes** | OAct-01.2 Command Rover Motion |
+
+#### SF-02.1 — Compute Drive Commands
+- Converts linear + angular velocity into per-wheel speed setpoints
+- Applies rocker-bogie kinematics model for differential drive
+
+#### SF-02.2 — Drive Wheels
+- Sends PWM signals to motor controllers for all six drive wheels
+- Enforces maximum speed limits
+
+#### SF-02.3 — Steer Corner Wheels
+- Positions four corner wheel servo motors to achieve commanded heading
+- Computes Ackermann steering angles from rover geometry
+
+---
+
+### SF-03 — Manage Power
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Raw DC from battery, load current demands |
+| **Outputs** | Regulated voltages to all subsystems, battery state data |
+| **Realizes** | OAct-02.1 Charge Battery (monitoring); OAct-01.3 Monitor Rover State |
+
+#### SF-03.1 — Distribute Electrical Power
+- Steps down battery voltage to regulated rails (5V logic, 12V motor supply)
+- Provides switched outputs to motors and compute
+
+#### SF-03.2 — Monitor Battery State
+- Reads battery voltage and current via ADC / INA sensor
+- Computes state-of-charge estimate
+- Publishes battery percentage to telemetry stream
+
+#### SF-03.3 — Protect Against Overcurrent/Short
+- Implements fuse and/or software overcurrent cutoff
+- Triggers SF-06.4 Safe Stop on detected fault
+
+---
+
+### SF-04 — Process and Publish Telemetry
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Sensor samples (IMU, encoders, current monitors) |
+| **Outputs** | Telemetry packet (orientation, wheel speeds, battery, faults) |
+| **Realizes** | OAct-01.3 Monitor Rover State |
+
+#### SF-04.1 — Sample Sensors
+- Reads IMU (accelerometer + gyroscope) at ≥ 10 Hz
+- Reads wheel encoder ticks at ≥ 20 Hz
+- Reads motor current at ≥ 10 Hz
+
+#### SF-04.2 — Estimate Rover State
+- Integrates encoder data for odometry (dead-reckoning position estimate)
+- Applies complementary filter or Madgwick filter for attitude estimate
+
+#### SF-04.3 — Transmit Telemetry
+- Serializes state estimate and sensor data as ROS messages
+- Publishes over Wi-Fi to ground station subscriber
+
+---
+
+### SF-05 — Capture and Stream Video
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Camera sensor data |
+| **Outputs** | Compressed video stream (MJPEG or H.264) |
+| **Realizes** | OAct-01.5 Collect Sensor Data |
+| **Notes** | Optional function; enabled when camera is installed |
+
+---
+
+### SF-06 — Detect and Handle Faults
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Motor current readings, battery voltage, IMU roll/pitch |
+| **Outputs** | Fault flags, safe-stop command |
+| **Realizes** | OAct-01.4 Respond to Hazard |
+
+#### SF-06.4 — Execute Safe Stop
+- Immediately sets all drive motor setpoints to zero
+- Publishes fault event to telemetry
+- Holds SAFE STOP state until operator acknowledges
+
+---
+
+### SF-07 — Support Payload Interface
+
+| Attribute | Value |
+|---|---|
+| **Inputs** | Payload power request, payload data output |
+| **Outputs** | Switched 5V/12V power, routed data bus (USB / serial / I²C) |
+| **Realizes** | OAct-04.2 Integrate Payload |
+
+## Function-to-Operational-Activity Traceability
+
+| System Function | Realized Operational Activity |
+|---|---|
+| SF-01 | OAct-01.2 Command Rover Motion |
+| SF-02 | OAct-01.2 Command Rover Motion |
+| SF-03 | OAct-02.1 Charge Battery, OAct-01.3 Monitor Rover State |
+| SF-04 | OAct-01.3 Monitor Rover State |
+| SF-05 | OAct-01.5 Collect Sensor Data |
+| SF-06 | OAct-01.4 Respond to Hazard |
+| SF-07 | OAct-04.2 Integrate Payload |

--- a/systems_engineering/03_logical_architecture/README.md
+++ b/systems_engineering/03_logical_architecture/README.md
@@ -1,0 +1,62 @@
+# Logical Architecture (LA)
+
+**Arcadia Layer 3 of 5**
+
+The Logical Architecture answers the question: **HOW (abstractly) does the system work?** It decomposes the system into logical components and allocates system functions to those components, without yet specifying physical hardware or software technology choices.
+
+## Purpose
+
+The LA defines the **solution concept**: how the OSR system is organized into cooperating subsystems. Logical components are technology-agnostic — they describe functional roles, not physical devices. Each logical component realizes one or more system functions and may expose interfaces to other components.
+
+## Documents
+
+| Document | Contents |
+|---|---|
+| [Logical Components](logical_components.md) | Subsystem decomposition and responsibilities |
+| [Logical Functions](logical_functions.md) | Function allocation to logical components |
+| [Interfaces](interfaces.md) | Inter-component logical interfaces |
+
+## Logical Architecture Block (LAB)
+
+```
+┌───────────────────────── Logical System ───────────────────────────┐
+│                                                                     │
+│  ┌────────────────┐    ┌────────────────┐    ┌────────────────┐    │
+│  │ LC-01          │    │ LC-02          │    │ LC-03          │    │
+│  │ Communication  │───►│ Command        │───►│ Mobility       │    │
+│  │ Manager        │    │ Processor      │    │ Controller     │    │
+│  └────────────────┘    └───────┬────────┘    └───────┬────────┘    │
+│                                │                     │             │
+│                                ▼                     ▼             │
+│  ┌────────────────┐    ┌────────────────┐    ┌────────────────┐    │
+│  │ LC-04          │    │ LC-05          │    │ LC-06          │    │
+│  │ State          │◄───│ Fault Monitor  │    │ Power Manager  │    │
+│  │ Estimator      │    │                │    │                │    │
+│  └───────┬────────┘    └────────────────┘    └───────┬────────┘    │
+│          │                                           │             │
+│          ▼                                           ▼             │
+│  ┌────────────────┐                         ┌────────────────┐    │
+│  │ LC-07          │                         │ LC-08          │    │
+│  │ Telemetry      │                         │ Payload        │    │
+│  │ Publisher      │                         │ Manager        │    │
+│  └────────────────┘                         └────────────────┘    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Summary
+
+| ID | Component | Realizes SF | Key Responsibility |
+|---|---|---|---|
+| LC-01 | Communication Manager | SF-01, SF-04.3, SF-05 | Wi-Fi packet I/O, message routing |
+| LC-02 | Command Processor | SF-01 | Decodes, validates, and dispatches commands |
+| LC-03 | Mobility Controller | SF-02 | Kinematic computation and motor command generation |
+| LC-04 | State Estimator | SF-04.1, SF-04.2 | Sensor fusion, odometry, attitude estimate |
+| LC-05 | Fault Monitor | SF-06 | Health monitoring and safe-stop triggering |
+| LC-06 | Power Manager | SF-03 | Power distribution, battery monitoring |
+| LC-07 | Telemetry Publisher | SF-04.3 | Formats and transmits telemetry |
+| LC-08 | Payload Manager | SF-07 | Payload power switching and data routing |
+
+## Traceability
+
+- Logical Components realize **System Functions** from [SA layer](../02_system_analysis/system_functions.md)
+- Logical Components are realized by **Physical Components** in [PA layer](../04_physical_architecture/README.md)

--- a/systems_engineering/03_logical_architecture/interfaces.md
+++ b/systems_engineering/03_logical_architecture/interfaces.md
@@ -1,0 +1,124 @@
+# Logical Interfaces
+
+**LA Layer — Logical Interface Register**
+
+Logical Interfaces (LIFs) define the data and control flows between Logical Components. They are independent of physical technology — they describe what is exchanged, not how it travels.
+
+## Interface Register
+
+| ID | Interface | Source LC | Target LC | Data Exchanged | Direction |
+|---|---|---|---|---|---|
+| LIF-01 | Command Flow | LC-01 | LC-02 | Motion command (v, ω) | Unidirectional |
+| LIF-02 | Halt Signal | LC-02 | LC-03 | Emergency stop flag | Unidirectional |
+| LIF-03 | Motion Intent | LC-02 | LC-03 | (v_linear, v_angular) | Unidirectional |
+| LIF-04 | Drive Setpoints | LC-03 | [Motor Interface] | 6× speed setpoint | Unidirectional |
+| LIF-05 | Steering Setpoints | LC-03 | [Servo Interface] | 4× angle setpoint | Unidirectional |
+| LIF-06 | Encoder Data | [Encoder Interface] | LC-04 | 6× tick count | Unidirectional |
+| LIF-07 | IMU Data | [IMU Interface] | LC-04 | Accel (3-axis), Gyro (3-axis) | Unidirectional |
+| LIF-08 | Motor Current | [Current Sensor] | LC-04 | 6× motor current (A) | Unidirectional |
+| LIF-09 | State Estimate | LC-04 | LC-07 | Odometry, attitude, wheel speeds | Unidirectional |
+| LIF-10 | State for Fault | LC-04 | LC-05 | Motor currents, attitude, battery | Unidirectional |
+| LIF-11 | Fault Halt | LC-05 | LC-02 | HALT command | Unidirectional |
+| LIF-12 | Fault Event | LC-05 | LC-07 | Fault type, timestamp | Unidirectional |
+| LIF-13 | Battery State | LC-06 | LC-05 | Voltage, current, SoC% | Unidirectional |
+| LIF-14 | Battery Telemetry | LC-06 | LC-07 | Voltage, current, SoC% | Unidirectional |
+| LIF-15 | Telemetry Output | LC-07 | LC-01 | Full telemetry bundle | Unidirectional |
+| LIF-16 | Video Stream | [Camera] | LC-01 | Compressed frames | Unidirectional |
+| LIF-17 | Payload Power Cmd | LC-02 | LC-08 | Power enable request | Unidirectional |
+| LIF-18 | Payload Data | LC-08 | LC-07 | Payload sensor output | Unidirectional |
+
+## Interface Data Definitions
+
+### LIF-01 — Command Flow
+
+```
+CommandMessage {
+  linear_velocity  : Float32   # m/s, range [-0.5, +0.5]
+  angular_velocity : Float32   # rad/s, range [-1.0, +1.0]
+  timestamp        : Time
+  sequence_number  : UInt32
+}
+```
+
+### LIF-09 — State Estimate
+
+```
+RoverState {
+  pose {
+    x : Float64  # m
+    y : Float64  # m
+    heading : Float32  # rad
+  }
+  velocity {
+    linear  : Float32  # m/s
+    angular : Float32  # rad/s
+  }
+  attitude {
+    roll  : Float32  # rad
+    pitch : Float32  # rad
+    yaw   : Float32  # rad
+  }
+  wheel_speeds[6] : Float32[]  # RPM per wheel
+  timestamp : Time
+}
+```
+
+### LIF-10 — State for Fault Monitor
+
+```
+FaultMonitorInputs {
+  motor_currents[6] : Float32[]  # Amperes
+  battery_voltage   : Float32   # Volts
+  battery_current   : Float32   # Amperes
+  roll              : Float32   # rad
+  pitch             : Float32   # rad
+  last_command_time : Time
+}
+```
+
+### LIF-12 — Fault Event
+
+```
+FaultEvent {
+  fault_type : Enum {
+    MOTOR_OVERCURRENT,
+    LOW_BATTERY_WARNING,
+    LOW_BATTERY_CRITICAL,
+    TILT_LIMIT,
+    COMMAND_TIMEOUT,
+    PAYLOAD_OVERCURRENT
+  }
+  affected_channel : UInt8   # motor index (0-5), or 0xFF for global
+  value_at_fault   : Float32 # measured value that triggered fault
+  timestamp        : Time
+}
+```
+
+## Component Interaction Diagram
+
+```
+Ground Station
+    │ (IF-01 Wi-Fi)
+    ▼
+LC-01 Communications Manager
+    │ LIF-01 command
+    ▼
+LC-02 Command Processor ◄── LIF-11 HALT (from LC-05)
+    │ LIF-03 motion intent
+    ▼
+LC-03 Mobility Controller
+    │ LIF-04  LIF-05
+    ▼         ▼
+ [Motors]  [Servos]
+
+LC-04 State Estimator ◄── LIF-06 encoders, LIF-07 IMU, LIF-08 currents
+    │ LIF-09          │ LIF-10
+    ▼                 ▼
+LC-07 Telemetry    LC-05 Fault Monitor
+    │ LIF-15           │ LIF-11 (to LC-02)
+    ▼                  │ LIF-12 (to LC-07)
+LC-01 ──► Ground       │
+Station           LC-06 Power Manager
+                      │ LIF-13 (to LC-05)
+                      └ LIF-14 (to LC-07)
+```

--- a/systems_engineering/03_logical_architecture/logical_components.md
+++ b/systems_engineering/03_logical_architecture/logical_components.md
@@ -1,0 +1,181 @@
+# Logical Components
+
+**LA Layer — Logical Component Register**
+
+Logical Components (LCs) are the **functional subsystems** of the OSR. They are defined by what they do, not by what physical hardware or software implements them. Each LC has a defined set of responsibilities, inputs, outputs, and interfaces.
+
+## LC-01 — Communication Manager
+
+**Responsibility:** All wireless data exchange between the rover and the ground station. Acts as the system's network gateway.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Network packets from ground station (commands, developer SSH) |
+| **Outputs** | Decoded command data to LC-02; outbound telemetry from LC-07; video from LC-07 |
+| **Realizes** | SF-01 (reception), SF-04.3 (transmission), SF-05 (video stream) |
+| **Watchdog role** | Times out command stream; notifies LC-02 if no packet in > 1 s |
+
+**Sub-functions:**
+- `receive_command_packet()` — listens on command socket/ROS topic
+- `transmit_telemetry_packet()` — forwards serialized telemetry to ground
+- `relay_video_stream()` — proxies camera data over network
+
+---
+
+## LC-02 — Command Processor
+
+**Responsibility:** Validates incoming commands, enforces safety limits, and dispatches motion intents to the Mobility Controller.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Raw command packets from LC-01 |
+| **Outputs** | Validated motion intent (linear velocity, angular velocity) to LC-03; halt signal to LC-03 on timeout |
+| **Realizes** | SF-01 |
+
+**Sub-functions:**
+- `decode_command()` — parses twist message into (v_linear, v_angular)
+- `apply_velocity_limits()` — clamps to max speed/turn rate
+- `handle_watchdog_timeout()` — outputs zero-motion intent if no command received
+- `relay_acknowledgment()` — confirms command receipt to LC-01
+
+---
+
+## LC-03 — Mobility Controller
+
+**Responsibility:** Converts commanded robot velocities into per-wheel drive and steering commands. Implements the kinematic model of the rocker-bogie platform.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Motion intent (v_linear, v_angular) from LC-02 |
+| **Outputs** | Six drive wheel speed setpoints; four steering angle setpoints |
+| **Realizes** | SF-02.1, SF-02.2, SF-02.3 |
+
+**Sub-functions:**
+- `compute_wheel_speeds(v, ω)` — applies differential drive / Ackermann kinematics
+- `compute_steering_angles(ω)` — derives per-corner servo positions
+- `output_drive_commands()` — writes speed setpoints to motor control interface
+- `output_steering_commands()` — writes angle setpoints to servo interface
+
+**Kinematics notes:**
+- The rocker-bogie geometry requires that each wheel pair (front, middle, rear) be driven at different speeds during a turn
+- Corner wheels (front and rear) steer; middle wheels are fixed-heading
+- Kinematic model accounts for rover wheelbase (L) and track width (W)
+
+---
+
+## LC-04 — State Estimator
+
+**Responsibility:** Collects raw sensor data and produces a fused estimate of rover state (position, orientation, velocity). Feeds both telemetry and fault monitoring.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Wheel encoder ticks (×6), IMU acceleration and gyroscope, motor current readings |
+| **Outputs** | Odometry estimate (pose, velocity), attitude estimate (roll, pitch, yaw), per-wheel current |
+| **Realizes** | SF-04.1, SF-04.2 |
+
+**Sub-functions:**
+- `sample_encoders()` — reads encoder counters at ≥ 20 Hz
+- `sample_imu()` — reads accelerometer and gyroscope at ≥ 50 Hz
+- `integrate_odometry()` — dead-reckoning from wheel encoder deltas
+- `estimate_attitude()` — complementary filter (accelerometer + gyroscope)
+- `publish_state()` — packages and sends state to LC-07 and LC-05
+
+---
+
+## LC-05 — Fault Monitor
+
+**Responsibility:** Continuously watches system health indicators and triggers safe stop actions when thresholds are exceeded.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Motor currents from LC-04, battery voltage from LC-06, attitude estimate from LC-04 |
+| **Outputs** | Fault flags; halt command to LC-02; fault event to LC-07 |
+| **Realizes** | SF-06 |
+
+**Monitored conditions:**
+
+| Condition | Threshold | Action |
+|---|---|---|
+| Motor overcurrent | Any motor > 10 A | Immediate safe stop + fault flag |
+| Low battery (warning) | Voltage < 11.0 V | Warning flag published to telemetry |
+| Low battery (critical) | Voltage < 10.5 V | Safe stop + fault flag |
+| Excessive tilt | Roll or pitch > 35° | Safe stop + fault flag |
+| Command watchdog | No command in > 1.0 s | Safe stop (no fault, standby) |
+
+**Recovery:** Operator sends explicit clear command; LC-05 verifies condition resolved before clearing halt.
+
+---
+
+## LC-06 — Power Manager
+
+**Responsibility:** Monitors battery and power rails; manages power distribution and protection.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Battery terminal voltage (ADC), rail current sensors |
+| **Outputs** | Battery state (voltage, current, SoC%) to LC-05 and LC-07; switched power enables to motor controllers and payload |
+| **Realizes** | SF-03 |
+
+**Sub-functions:**
+- `read_battery_voltage()` — reads ADC at 1 Hz
+- `estimate_state_of_charge()` — voltage-curve lookup for LiPo
+- `monitor_rail_current()` — reads current sensor for total draw
+- `control_power_switches()` — enables/disables load switches on fault
+
+---
+
+## LC-07 — Telemetry Publisher
+
+**Responsibility:** Aggregates state estimates, fault flags, and sensor data; formats and forwards to LC-01 for transmission.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | State from LC-04, power data from LC-06, fault flags from LC-05 |
+| **Outputs** | Serialized telemetry packets to LC-01 |
+| **Realizes** | SF-04.3 |
+| **Rate** | ≥ 5 Hz publish cycle |
+
+**Published content:**
+- Odometry (pose + velocity)
+- IMU attitude
+- Battery voltage, current, SoC%
+- Per-wheel speeds
+- Per-motor current
+- Active fault flags
+- Camera frame (if SF-05 enabled)
+
+---
+
+## LC-08 — Payload Manager
+
+**Responsibility:** Controls power delivery to optional payload devices and routes payload data to the compute stack.
+
+| Attribute | Detail |
+|---|---|
+| **Inputs** | Payload power enable request, payload data |
+| **Outputs** | Switched 5V/12V power, routed data (USB/I²C) to onboard compute |
+| **Realizes** | SF-07 |
+
+**Sub-functions:**
+- `enable_payload_power(rail, enable)` — controls load switch for payload power rails
+- `monitor_payload_current()` — ensures payload draw does not exceed allocation
+- `route_payload_data()` — logical pass-through of USB/I²C to compute
+
+## Component Dependencies
+
+```
+LC-01 (Comms)
+  └── LC-02 (Command Processor) ── LC-03 (Mobility Controller)
+                                         │
+                                  Motor/Servo outputs
+
+LC-04 (State Estimator) ──► LC-05 (Fault Monitor)
+        │                           │
+        └──────► LC-07 (Telemetry) ◄┘
+                        │
+                   LC-01 (Comms) ──► Ground Station
+
+LC-06 (Power Manager) ──► LC-05 (Fault Monitor)
+                     └──► LC-07 (Telemetry)
+                     └──► LC-08 (Payload Manager)
+```

--- a/systems_engineering/03_logical_architecture/logical_functions.md
+++ b/systems_engineering/03_logical_architecture/logical_functions.md
@@ -1,0 +1,64 @@
+# Logical Functions
+
+**LA Layer — Logical Function Allocation**
+
+Logical Functions (LFs) refine System Functions from the SA layer into more detailed function descriptions and allocate them to specific Logical Components. Each LF traces to a parent System Function (SF) and is owned by one LC.
+
+## Function-to-Component Allocation Matrix
+
+| LF ID | Logical Function | Parent SF | Allocated to LC | Rate |
+|---|---|---|---|---|
+| LF-01.1 | Receive ROS command topic | SF-01 | LC-01 | 10 Hz |
+| LF-01.2 | Validate command packet integrity | SF-01 | LC-02 | 10 Hz |
+| LF-01.3 | Apply velocity limits | SF-01 | LC-02 | 10 Hz |
+| LF-01.4 | Detect command watchdog timeout | SF-01 | LC-02 | 1 Hz |
+| LF-02.1 | Compute differential drive kinematics | SF-02.1 | LC-03 | 20 Hz |
+| LF-02.2 | Compute Ackermann corner angles | SF-02.3 | LC-03 | 20 Hz |
+| LF-02.3 | Output drive PWM setpoints | SF-02.2 | LC-03 | 20 Hz |
+| LF-02.4 | Output steering angle setpoints | SF-02.3 | LC-03 | 20 Hz |
+| LF-03.1 | Read battery voltage (ADC) | SF-03.2 | LC-06 | 1 Hz |
+| LF-03.2 | Estimate state-of-charge | SF-03.2 | LC-06 | 1 Hz |
+| LF-03.3 | Distribute regulated power rails | SF-03.1 | LC-06 | Continuous |
+| LF-03.4 | Engage overcurrent protection | SF-03.3 | LC-06 | Event |
+| LF-04.1 | Sample wheel encoders | SF-04.1 | LC-04 | 20 Hz |
+| LF-04.2 | Sample IMU | SF-04.1 | LC-04 | 50 Hz |
+| LF-04.3 | Sample motor currents | SF-04.1 | LC-04 | 10 Hz |
+| LF-04.4 | Integrate odometry from encoders | SF-04.2 | LC-04 | 20 Hz |
+| LF-04.5 | Estimate attitude (IMU filter) | SF-04.2 | LC-04 | 50 Hz |
+| LF-04.6 | Publish telemetry bundle | SF-04.3 | LC-07 | 5 Hz |
+| LF-05.1 | Monitor per-motor current | SF-06.1 | LC-05 | 10 Hz |
+| LF-05.2 | Monitor battery voltage | SF-06.2 | LC-05 | 1 Hz |
+| LF-05.3 | Monitor IMU tilt | SF-06.3 | LC-05 | 10 Hz |
+| LF-05.4 | Execute safe stop | SF-06.4 | LC-05 | Event |
+| LF-05.5 | Publish fault events | SF-06.4 | LC-05 | Event |
+| LF-06.1 | Stream video frames | SF-05 | LC-01 | 10 Hz |
+| LF-07.1 | Enable/disable payload power | SF-07.1 | LC-08 | On command |
+| LF-07.2 | Monitor payload current | SF-07.1 | LC-08 | 1 Hz |
+| LF-07.3 | Route payload data bus | SF-07.2 | LC-08 | Continuous |
+
+## Function Execution Timeline
+
+The following shows the cyclic execution pattern at steady state:
+
+```
+Time →   0ms   20ms   40ms   50ms  100ms  200ms
+         │      │      │      │      │      │
+LF-02.1  ●──────●──────●──────●──────●──────●   (20 Hz kinematics)
+LF-04.1  ●──────●──────●──────●──────●──────●   (20 Hz encoder read)
+LF-04.2  ●──●───●──●───●──●───●──●───●──●───●   (50 Hz IMU read)
+LF-05.1  ●──────────────────────●──────────────  (10 Hz current monitor)
+LF-03.1  ●────────────────────────────────────●  (1 Hz battery read)
+LF-04.6  ●───────────────────────────────────●   (5 Hz telemetry publish)
+```
+
+## Traceability: LF → SF → OAct
+
+| Logical Function | System Function | Operational Activity |
+|---|---|---|
+| LF-01.1 to LF-01.4 | SF-01 Receive and Decode Command | OAct-01.2 Command Rover Motion |
+| LF-02.1 to LF-02.4 | SF-02 Execute Mobility | OAct-01.2 Command Rover Motion |
+| LF-03.1 to LF-03.4 | SF-03 Manage Power | OAct-02.1 Charge Battery |
+| LF-04.1 to LF-04.6 | SF-04 Process and Publish Telemetry | OAct-01.3 Monitor Rover State |
+| LF-05.1 to LF-05.5 | SF-06 Detect and Handle Faults | OAct-01.4 Respond to Hazard |
+| LF-06.1 | SF-05 Capture and Stream Video | OAct-01.5 Collect Sensor Data |
+| LF-07.1 to LF-07.3 | SF-07 Support Payload Interface | OAct-04.2 Integrate Payload |

--- a/systems_engineering/04_physical_architecture/README.md
+++ b/systems_engineering/04_physical_architecture/README.md
@@ -1,0 +1,89 @@
+# Physical Architecture (PA)
+
+**Arcadia Layer 4 of 5**
+
+The Physical Architecture answers the question: **HOW (concretely) is the system built?** It maps each Logical Component to specific physical hardware or software, specifies technologies, and defines the physical deployment of functions onto components.
+
+## Purpose
+
+The PA binds the abstract solution from the LA to specific, procurable or manufacturable items. It identifies every physical node, the software that runs on each, and how they are electrically, mechanically, and logically connected.
+
+## Documents
+
+| Document | Contents |
+|---|---|
+| [Physical Components](physical_components.md) | Hardware and software components |
+| [Physical Functions](physical_functions.md) | Function deployment to physical nodes |
+| [Interfaces](interfaces.md) | Physical wiring, connectors, and protocols |
+
+## Physical Architecture Block (PAB)
+
+```
+┌──────────────────────────── OSR Physical System ─────────────────────────────┐
+│                                                                               │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │                     BODY ELECTRONICS ENCLOSURE                         │  │
+│  │                                                                         │  │
+│  │  ┌─────────────┐   ┌──────────────────────────────────────────────┐   │  │
+│  │  │ Raspberry   │   │         Custom OSR PCB                       │   │  │
+│  │  │   Pi 4B     │◄──┤  ┌────────┐  ┌──────────┐  ┌─────────────┐  │   │  │
+│  │  │  (Compute)  │   │  │ Logic  │  │  Power   │  │  Expansion  │  │   │  │
+│  │  │             │──►│  │ Supply │  │ Reg/Dist │  │   Headers   │  │   │  │
+│  │  │  Wi-Fi ◄────┼───┤  │  5V   │  │ 5V / 12V │  │  I2C/UART  │  │   │  │
+│  │  │  SSH/ROS    │   │  └────────┘  └──────────┘  └─────────────┘  │   │  │
+│  │  └─────────────┘   │                                               │   │  │
+│  │         │          └──────────────────────────────────────────────┘   │  │
+│  │         │ USB × 6                                                       │  │
+│  │         ▼                                                               │  │
+│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐                 │  │
+│  │  │ RoboClaw    │  │  RoboClaw    │  │  RoboClaw    │                 │  │
+│  │  │ 2×15A       │  │  2×15A       │  │  2×15A       │                 │  │
+│  │  │ (Left Front)│  │ (Left Mid)   │  │ (Left Rear)  │                 │  │
+│  │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘                 │  │
+│  └─────────┼─────────────────┼─────────────────┼─────────────────────────┘  │
+│            │ Motor power (12V + signal)         │                            │
+│   ┌────────▼────┐  ┌─────────▼────┐  ┌─────────▼────┐                      │
+│   │ Drive Motor │  │ Drive Motor  │  │ Drive Motor  │    (×6 total)          │
+│   │ Left Front  │  │ Left Middle  │  │ Left Rear    │                        │
+│   └─────────────┘  └──────────────┘  └──────────────┘                       │
+│                                                                               │
+│   ┌──────────────────┐                                                        │
+│   │  Battery Pack    │ 3S LiPo 11.1V  ──► PCB Power Input                   │
+│   └──────────────────┘                                                        │
+│                                                                               │
+│   ┌──────────────────┐                                                        │
+│   │   IMU (BNO055    │ I²C ──► RPi GPIO                                      │
+│   │   or MPU-6050)   │                                                        │
+│   └──────────────────┘                                                        │
+│                                                                               │
+│   ┌──────────────────┐                                                        │
+│   │  Pi Camera / USB │ CSI / USB ──► RPi                                     │
+│   │  Camera          │                                                        │
+│   └──────────────────┘                                                        │
+│                                                                               │
+│   ┌──────────────────────────────────────────────────┐                       │
+│   │         CORNER STEERING SERVOS (×4)              │                       │
+│   │  Servo (FR) + Servo (FL) + Servo (RR) + Servo(RL)│                      │
+│   │  Controlled via PWM from RPi GPIO / PCA9685      │                       │
+│   └──────────────────────────────────────────────────┘                       │
+│                                                                               │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Logical-to-Physical Mapping
+
+| Logical Component | Physical Component(s) |
+|---|---|
+| LC-01 Communication Manager | Raspberry Pi 4B (Wi-Fi), ROS network stack |
+| LC-02 Command Processor | Raspberry Pi 4B, ROS `osr_control` node |
+| LC-03 Mobility Controller | Raspberry Pi 4B, ROS `osr_drive` node, RoboClaw controllers (×3), servo driver |
+| LC-04 State Estimator | Raspberry Pi 4B, ROS `osr_state` node, IMU, wheel encoders |
+| LC-05 Fault Monitor | Raspberry Pi 4B, ROS `osr_safety` node |
+| LC-06 Power Manager | Custom OSR PCB (voltage regulators, current monitor INA219) |
+| LC-07 Telemetry Publisher | Raspberry Pi 4B, ROS publishers |
+| LC-08 Payload Manager | Custom OSR PCB (load switches), RPi USB/I²C |
+
+## Traceability
+
+- Physical Components realize **Logical Components** from [LA layer](../03_logical_architecture/logical_components.md)
+- Physical Components are broken down into **Configuration Items** in [EPBS layer](../05_epbs/README.md)

--- a/systems_engineering/04_physical_architecture/interfaces.md
+++ b/systems_engineering/04_physical_architecture/interfaces.md
@@ -1,0 +1,103 @@
+# Physical Interfaces
+
+**PA Layer — Physical Interface Register**
+
+Physical Interfaces specify the actual connectors, wires, buses, and protocols that connect Physical Components. Each physical interface realizes one or more logical interfaces.
+
+## Interface Register
+
+| ID | Interface | Source PC | Target PC | Physical Medium | Protocol | Realizes LIF |
+|---|---|---|---|---|---|---|
+| PIF-01 | Wi-Fi Command | Ground Station | PC-COMP-01 | 802.11ac 2.4/5 GHz | UDP/TCP ROS | LIF-01 |
+| PIF-02 | Wi-Fi Telemetry | PC-COMP-01 | Ground Station | 802.11ac | TCP ROS | LIF-15 |
+| PIF-03 | Wi-Fi Video | PC-COMP-01 | Ground Station | 802.11ac | HTTP MJPEG | LIF-16 |
+| PIF-04 | USB Serial (RoboClaw 1) | PC-COMP-01 | PC-MCTL-01a | USB-B cable | Basicmicro serial API | LIF-04, LIF-06 |
+| PIF-05 | USB Serial (RoboClaw 2) | PC-COMP-01 | PC-MCTL-01b | USB-B cable | Basicmicro serial API | LIF-04, LIF-06 |
+| PIF-06 | USB Serial (RoboClaw 3) | PC-COMP-01 | PC-MCTL-01c | USB-B cable | Basicmicro serial API | LIF-04, LIF-06 |
+| PIF-07 | I²C Bus (IMU) | PC-COMP-01 | PC-SENS-01 | Twisted pair, 3.3V | I²C 400 kHz | LIF-07 |
+| PIF-08 | I²C Bus (Power Monitor) | PC-COMP-01 | PC-SENS-03 | PCB trace | I²C 100 kHz | LIF-13, LIF-14 |
+| PIF-09 | I²C Bus (Servo Driver) | PC-COMP-01 | PCA9685 | Twisted pair, 3.3V | I²C 400 kHz | LIF-05 |
+| PIF-10 | PWM (Corner Servos) | PCA9685 | PC-MCTL-02 (×4) | 3-wire servo cable | 50 Hz PWM | LIF-05 |
+| PIF-11 | Motor Power (Front L/R) | PC-PCB-01 | PC-MCTL-01a | 14 AWG wire, XT30 | 12V DC | — |
+| PIF-12 | Motor Power (Mid L/R) | PC-PCB-01 | PC-MCTL-01b | 14 AWG wire, XT30 | 12V DC | — |
+| PIF-13 | Motor Power (Rear L/R) | PC-PCB-01 | PC-MCTL-01c | 14 AWG wire, XT30 | 12V DC | — |
+| PIF-14 | Drive Motor Wires (×6) | PC-MCTL-01(×3) | PC-MECH-03 motors | 18 AWG wire | Brushed DC | LIF-04 |
+| PIF-15 | Battery Input | PC-PWR-01 | PC-PCB-01 | 12 AWG wire, XT60 | 11.1V LiPo | IF-04 |
+| PIF-16 | 5V RPi Power | PC-PCB-01 | PC-COMP-01 | USB-C cable | 5V / 3A USB-C | IF-04 |
+| PIF-17 | Camera Interface | PC-CAM-01 | PC-COMP-01 | CSI ribbon (or USB) | MIPI CSI-2 / USB | LIF-16 |
+| PIF-18 | GPIO (RPi → PCB) | PC-COMP-01 | PC-PCB-01 | 40-pin GPIO header | 3.3V GPIO | LIF-17 |
+
+## Detailed Interface Specifications
+
+### PIF-04/05/06 — RoboClaw USB Serial
+
+| Attribute | Value |
+|---|---|
+| Connector | USB Type-B (device side) |
+| Cable length | ≤ 0.5 m (within body enclosure) |
+| Baud rate | 115200 bps |
+| Protocol | Basicmicro packet serial protocol |
+| Commands used | `M1M2(speed)`, `ReadEncoders()`, `ReadCurrents()`, `SetEncM1(0)` |
+| I²C address | N/A (USB only) |
+
+**Critical:** Each RoboClaw must be assigned a unique address (0x80, 0x81, 0x82) via the Basicmicro Motion Studio configuration tool before first use.
+
+---
+
+### PIF-07 — I²C Bus (IMU — BNO055)
+
+| Attribute | Value |
+|---|---|
+| Signal lines | SDA, SCL, GND, 3.3V |
+| Connector | 4-pin JST-PH or Qwiic |
+| Pull-up resistors | 4.7 kΩ (on PCB) |
+| I²C address | 0x28 (default) or 0x29 (alt) |
+| Max cable length | 0.3 m (with 4.7k pull-ups at 400 kHz) |
+
+---
+
+### PIF-10 — Servo PWM (PCA9685 → Servos)
+
+| Attribute | Value |
+|---|---|
+| Connector | JR/Futaba 3-pin servo connector |
+| Signal voltage | 3.3V (compatible with 5V servos) |
+| Frequency | 50 Hz (20 ms period) |
+| Pulse width | 1.0 ms (full left) to 2.0 ms (full right), 1.5 ms center |
+| Channels used | 0 (FL), 1 (FR), 2 (RL), 3 (RR) |
+
+---
+
+### PIF-15 — Battery to PCB (XT60)
+
+| Attribute | Value |
+|---|---|
+| Connector | XT60 (male on battery, female on PCB) |
+| Wire gauge | 12 AWG silicone |
+| Fuse | 30A blade fuse in-line |
+| Polarity protection | Reverse-polarity diode or keyed connector |
+
+---
+
+## Wiring Harness Summary
+
+| Harness | From | To | Wires | Notes |
+|---|---|---|---|---|
+| Battery harness | Battery XT60 | PCB XT60 | 2× 12 AWG | Include in-line 30A fuse |
+| 5V power | PCB USB-C out | RPi USB-C | USB-C to USB-C | Use quality cable; 3A rated |
+| Motor power (×3) | PCB XT30 out | RoboClaw Vbat | 2× 14 AWG | One harness per RoboClaw |
+| Motor wires (×6) | RoboClaw M1/M2 | Wheel motor | 2× 18 AWG | ~300–500 mm each |
+| USB serial (×3) | RPi USB-A | RoboClaw USB-B | USB-A to USB-B | ≤ 500 mm |
+| I²C IMU | RPi GPIO header | IMU board | 4-wire | 100–300 mm |
+| I²C servo | RPi GPIO header | PCA9685 | 4-wire | 100–200 mm |
+| Servo wires (×4) | PCA9685 header | Servo (×4) | 3-wire | 200–500 mm each |
+
+## I²C Address Map
+
+| Device | Address | Bus |
+|---|---|---|
+| BNO055 IMU | 0x28 | RPi GPIO I²C-1 |
+| INA219 Battery Monitor | 0x40 | RPi GPIO I²C-1 |
+| PCA9685 Servo Driver | 0x60 | RPi GPIO I²C-1 |
+
+**Note:** Ensure no address conflicts; all three can share the same I²C bus at their default addresses.

--- a/systems_engineering/04_physical_architecture/physical_components.md
+++ b/systems_engineering/04_physical_architecture/physical_components.md
@@ -1,0 +1,225 @@
+# Physical Components
+
+**PA Layer — Physical Component Register**
+
+Physical Components (PCs) are the actual hardware items and software modules that implement the logical architecture. Each PC traces to one or more Logical Components.
+
+## Compute Subsystem
+
+### PC-COMP-01 — Raspberry Pi 4B (or equivalent SBC)
+
+| Attribute | Value |
+|---|---|
+| **Type** | Single-board computer |
+| **Processor** | Broadcom BCM2711, quad-core ARM Cortex-A72, 1.5 GHz |
+| **RAM** | 4 GB LPDDR4 (minimum) |
+| **Storage** | 32 GB microSD (minimum) |
+| **OS** | Raspberry Pi OS (Bullseye / Bookworm) |
+| **Software** | ROS Noetic / ROS 2 Humble |
+| **Connectivity** | 802.11ac Wi-Fi, Bluetooth 5.0, USB 3.0 ×2, USB 2.0 ×2, GPIO 40-pin |
+| **Power input** | 5V / 3A via USB-C |
+| **Realizes** | LC-01, LC-02, LC-03, LC-04, LC-05, LC-07 |
+
+**Deployed ROS Nodes:**
+
+| Node | Logical Function | Description |
+|---|---|---|
+| `osr_control/command_node` | LC-02 | Receives `/cmd_vel`, applies limits, outputs to drive node |
+| `osr_drive/drive_node` | LC-03 | Kinematics computation, publishes to RoboClaw and servo |
+| `osr_state/imu_node` | LC-04 | IMU driver and attitude estimation |
+| `osr_state/encoder_node` | LC-04 | Encoder reading and odometry integration |
+| `osr_safety/fault_node` | LC-05 | Health monitoring and safe-stop logic |
+| `osr_comms/telemetry_node` | LC-07 | Aggregates and publishes telemetry |
+| `camera_node` | LC-01 | Video capture and streaming |
+
+---
+
+## Motor Control Subsystem
+
+### PC-MCTL-01 — RoboClaw 2×15A Motor Controller
+
+| Attribute | Value |
+|---|---|
+| **Type** | Dual-channel DC motor controller |
+| **Channels per unit** | 2 |
+| **Units installed** | 3 (total 6 drive channels) |
+| **Max current per channel** | 15 A continuous, 30 A peak |
+| **Input voltage** | 6–34 V DC |
+| **Control interface** | USB Serial (USB-B to RPi) |
+| **Feedback** | Quadrature encoder input (up to 2M pulses/s) |
+| **Realizes** | LC-03 (SF-02.2 drive execution) |
+| **Supplier** | Basicmicro (formerly Orion Robotics) |
+
+**Channel assignment:**
+
+| RoboClaw Unit | Channel 1 | Channel 2 |
+|---|---|---|
+| Unit 1 | Front Left Drive | Front Right Drive |
+| Unit 2 | Middle Left Drive | Middle Right Drive |
+| Unit 3 | Rear Left Drive | Rear Right Drive |
+
+---
+
+### PC-MCTL-02 — Corner Steering Servo
+
+| Attribute | Value |
+|---|---|
+| **Type** | Digital PWM servo (high-torque) |
+| **Quantity** | 4 (front-left, front-right, rear-left, rear-right) |
+| **Stall torque** | ≥ 15 kg·cm |
+| **Control** | 50 Hz PWM (1–2 ms pulse width) |
+| **Interface** | PCA9685 I²C PWM driver → RPi I²C |
+| **Realizes** | LC-03 (SF-02.3 steering) |
+
+---
+
+## Electronics / PCB Subsystem
+
+### PC-PCB-01 — Custom OSR Control PCB
+
+| Attribute | Value |
+|---|---|
+| **Type** | Custom designed PCB |
+| **Function** | Power distribution, logic regulation, I/O breakout |
+| **Input** | 11.1V 3S LiPo (XT60 connector) |
+| **5V regulated output** | For RPi, logic, servos via DC-DC buck converter |
+| **12V switched outputs** | For drive motors via RoboClaw units |
+| **Current monitoring** | INA219 I²C current/voltage sensor |
+| **Emergency stop** | Latching push-button circuit |
+| **Connectors** | JST-PH for servos, screw terminals for motors, USB for RoboClaw |
+| **Realizes** | LC-06 (SF-03 power management) |
+
+---
+
+## Sensor Subsystem
+
+### PC-SENS-01 — Inertial Measurement Unit (IMU)
+
+| Attribute | Value |
+|---|---|
+| **Model** | BNO055 (9-DOF, internal fusion) or MPU-6050 |
+| **Interface** | I²C (address 0x28 / 0x29) |
+| **Output** | Quaternion orientation, linear acceleration, angular velocity |
+| **Sample rate** | Up to 100 Hz |
+| **Mounting** | Body top plate, orientation-aligned with rover frame |
+| **Realizes** | LC-04 (SF-04.1 sensor sampling) |
+
+### PC-SENS-02 — Wheel Encoder (per drive motor)
+
+| Attribute | Value |
+|---|---|
+| **Type** | Quadrature magnetic encoder |
+| **Resolution** | ≥ 64 CPR (counts per revolution) at motor shaft |
+| **Interface** | Differential quadrature to RoboClaw encoder input |
+| **Quantity** | 6 (one per drive motor) |
+| **Realizes** | LC-04 (SF-04.1 sensor sampling) |
+
+### PC-SENS-03 — Battery Current/Voltage Monitor
+
+| Attribute | Value |
+|---|---|
+| **IC** | INA219 (or INA226) |
+| **Interface** | I²C |
+| **Measurement** | Bus voltage (0–26V), shunt current via 0.1Ω resistor |
+| **Accuracy** | ±1% full-scale |
+| **Location** | On custom PCB |
+| **Realizes** | LC-06 (SF-03.2 battery monitoring) |
+
+---
+
+## Camera Subsystem
+
+### PC-CAM-01 — Onboard Camera
+
+| Attribute | Value |
+|---|---|
+| **Options** | Raspberry Pi Camera Module 3 (CSI) or USB webcam |
+| **Resolution** | ≥ 1920×1080 |
+| **Frame rate** | ≥ 30 fps (video) |
+| **Interface** | CSI ribbon or USB 2.0 |
+| **Realizes** | LC-01 (SF-05 video streaming) |
+
+---
+
+## Power Subsystem
+
+### PC-PWR-01 — Battery Pack
+
+| Attribute | Value |
+|---|---|
+| **Chemistry** | Lithium Polymer (LiPo) |
+| **Configuration** | 3S (3-cell series) |
+| **Nominal voltage** | 11.1 V |
+| **Capacity** | 5200 mAh (minimum) |
+| **Max discharge** | ≥ 20C |
+| **Connector** | XT60 |
+| **Runtime (typical)** | ~1–2 hours moderate operation |
+
+### PC-PWR-02 — Battery Charger
+
+| Attribute | Value |
+|---|---|
+| **Type** | Balance charger (e.g., iCharger, SkyRC) |
+| **Compatibility** | 3S LiPo |
+| **Charge rate** | ≤ 1C (5.2A for 5200 mAh) |
+| **Balance port** | Required (3-cell JST-XH) |
+
+---
+
+## Mechanical Subsystem
+
+### PC-MECH-01 — Chassis / Body Frame
+
+| Attribute | Value |
+|---|---|
+| **Material** | Aluminum extrusion and plate (6061-T6 or equivalent) |
+| **Construction** | Bolt-together; no welding |
+| **Dimensions** | Approximately 500 mm × 350 mm × 200 mm (L×W×H body) |
+| **Mass** | ~5 kg (bare chassis) |
+
+### PC-MECH-02 — Rocker-Bogie Suspension
+
+| Attribute | Value |
+|---|---|
+| **Type** | Passive differential rocker-bogie |
+| **Material** | Aluminum tube and plate |
+| **Pivot joints** | Shoulder screws, flanged bearings |
+| **Differential** | Cross-body differential bar (equalizes rocker pitch) |
+| **Max obstacle** | ~75 mm (one wheel-radius) |
+
+### PC-MECH-03 — Wheel Assembly (×6)
+
+| Attribute | Value |
+|---|---|
+| **Wheel diameter** | ~150 mm |
+| **Tire** | Rubber or 3D-printed TPU |
+| **Hub** | Aluminum hub, keyed to motor shaft |
+| **Drive motor mount** | Integrated into wheel bracket |
+
+### PC-MECH-04 — Corner Steering Assembly (×4)
+
+| Attribute | Value |
+|---|---|
+| **Type** | Servo-actuated pivot |
+| **Steering range** | ±30° from center |
+| **Construction** | Aluminum bracket, pivot bearing, servo horn |
+
+---
+
+## Physical Component Realization Traceability
+
+| Physical Component | Logical Component Realized |
+|---|---|
+| PC-COMP-01 Raspberry Pi 4B | LC-01, LC-02, LC-03, LC-04, LC-05, LC-07 |
+| PC-MCTL-01 RoboClaw (×3) | LC-03 |
+| PC-MCTL-02 Corner Servos (×4) | LC-03 |
+| PC-PCB-01 Control PCB | LC-06, LC-08 |
+| PC-SENS-01 IMU | LC-04 |
+| PC-SENS-02 Encoders (×6) | LC-04 |
+| PC-SENS-03 Battery Monitor | LC-06 |
+| PC-CAM-01 Camera | LC-01 |
+| PC-PWR-01 Battery Pack | LC-06 (external) |
+| PC-MECH-01 Chassis | LC-03 (structural host) |
+| PC-MECH-02 Rocker-Bogie | LC-03 (passive mobility) |
+| PC-MECH-03 Wheel Assembly (×6) | LC-03 |
+| PC-MECH-04 Corner Assembly (×4) | LC-03 |

--- a/systems_engineering/04_physical_architecture/physical_functions.md
+++ b/systems_engineering/04_physical_architecture/physical_functions.md
@@ -1,0 +1,76 @@
+# Physical Functions
+
+**PA Layer — Physical Function Deployment**
+
+Physical Functions (PFs) refine Logical Functions and deploy them onto specific Physical Components. This layer specifies which processor, microcontroller, or hardware circuit executes each function.
+
+## Deployment Map
+
+| PF ID | Physical Function | Parent LF | Deployed on PC | Technology |
+|---|---|---|---|---|
+| PF-01.1 | Subscribe to `/cmd_vel` ROS topic | LF-01.1 | PC-COMP-01 RPi | ROS Noetic subscriber |
+| PF-01.2 | Validate twist message fields | LF-01.2 | PC-COMP-01 RPi | Python / C++ ROS node |
+| PF-01.3 | Clamp velocity to configured limits | LF-01.3 | PC-COMP-01 RPi | Python `numpy.clip` |
+| PF-01.4 | Watchdog timer on `/cmd_vel` | LF-01.4 | PC-COMP-01 RPi | ROS timer callback (1 s) |
+| PF-02.1 | Rocker-bogie differential drive kinematics | LF-02.1 | PC-COMP-01 RPi | Python matrix solve |
+| PF-02.2 | Ackermann corner angle computation | LF-02.2 | PC-COMP-01 RPi | Python trig |
+| PF-02.3 | Write motor setpoint to RoboClaw via USB serial | LF-02.3 | PC-COMP-01 RPi → PC-MCTL-01 | `roboclaw` Python library |
+| PF-02.4 | Write angle setpoint to PCA9685 via I²C | LF-02.4 | PC-COMP-01 RPi → PC-MCTL-02 | `adafruit_servokit` |
+| PF-03.1 | Read INA219 battery voltage over I²C | LF-03.1 | PC-PCB-01 + PC-COMP-01 | INA219 driver |
+| PF-03.2 | Compute LiPo state-of-charge from voltage curve | LF-03.2 | PC-COMP-01 RPi | Python lookup table |
+| PF-03.3 | PCB DC-DC converter regulation | LF-03.3 | PC-PCB-01 | Hardware (buck converter) |
+| PF-03.4 | Software overcurrent cutoff via motor disable | LF-03.4 | PC-COMP-01 RPi | ROS fault node |
+| PF-04.1 | Read RoboClaw encoder counts via USB serial | LF-04.1 | PC-COMP-01 RPi ← PC-MCTL-01 | `roboclaw` library |
+| PF-04.2 | Read BNO055/MPU-6050 via I²C | LF-04.2 | PC-COMP-01 RPi ← PC-SENS-01 | IMU Python driver |
+| PF-04.3 | Read motor currents from RoboClaw via serial | LF-04.3 | PC-COMP-01 RPi ← PC-MCTL-01 | `roboclaw` library |
+| PF-04.4 | Integrate wheel ticks to odometry | LF-04.4 | PC-COMP-01 RPi | Python dead-reckoning |
+| PF-04.5 | Complementary filter for attitude | LF-04.5 | PC-COMP-01 RPi | Python filter |
+| PF-04.6 | Publish ROS telemetry topics at 5 Hz | LF-04.6 | PC-COMP-01 RPi | ROS publishers |
+| PF-05.1 | Monitor current thresholds per channel | LF-05.1 | PC-COMP-01 RPi | ROS subscriber |
+| PF-05.2 | Monitor battery voltage threshold | LF-05.2 | PC-COMP-01 RPi | ROS subscriber |
+| PF-05.3 | Monitor IMU roll/pitch threshold | LF-05.3 | PC-COMP-01 RPi | ROS subscriber |
+| PF-05.4 | Set all motor setpoints to zero | LF-05.4 | PC-COMP-01 RPi → PC-MCTL-01 | RoboClaw stop command |
+| PF-05.5 | Publish `/diagnostics` fault message | LF-05.5 | PC-COMP-01 RPi | ROS diagnostics |
+| PF-06.1 | Capture frames from camera module | LF-06.1 | PC-COMP-01 RPi ← PC-CAM-01 | `cv2` / `raspicam` |
+| PF-06.2 | Compress and stream video over Wi-Fi | LF-06.1 | PC-COMP-01 RPi | MJPEG / `cv_bridge` |
+| PF-07.1 | Toggle PCB load switch for payload power | LF-07.1 | PC-PCB-01 + RPi GPIO | GPIO digital output |
+| PF-07.2 | Read payload rail current via INA219 | LF-07.2 | PC-PCB-01 + PC-COMP-01 | INA219 driver |
+| PF-07.3 | Pass-through USB/I²C to RPi bus | LF-07.3 | PC-PCB-01 | Hardware traces |
+
+## Software Execution Environment
+
+All software PFs run on the Raspberry Pi 4B under:
+
+```
+OS:       Raspberry Pi OS (Debian Bullseye)
+Kernel:   Linux 5.15 (ARM64)
+Runtime:  Python 3.9 + ROS Noetic
+ROS WS:   ~/osr_ws/
+Launch:   roslaunch osr_bringup osr.launch
+```
+
+**Process architecture:**
+
+```
+rosmaster (ROS core)
+  ├── command_node     (10 Hz)   ← /cmd_vel
+  ├── drive_node       (20 Hz)   ← /commanded_vel → RoboClaw serial
+  ├── encoder_node     (20 Hz)   ← RoboClaw serial → /odom
+  ├── imu_node         (50 Hz)   ← I²C BNO055 → /imu
+  ├── fault_node       (10 Hz)   ← /motor_currents, /battery_state, /imu
+  ├── telemetry_node   (5 Hz)    → /diagnostics, /battery_state
+  ├── camera_node      (30 Hz)   ← CSI/USB → /camera/image_raw
+  └── power_node       (1 Hz)    ← I²C INA219 → /battery_state
+```
+
+## Hardware Timing Constraints
+
+| Function | Required Rate | Available Margin |
+|---|---|---|
+| Command reception | ≥ 10 Hz | ~40 Hz possible |
+| Drive PWM update | ≥ 20 Hz | RoboClaw supports 64 Hz |
+| IMU sampling | ≥ 50 Hz | BNO055 supports 100 Hz |
+| Encoder read | ≥ 20 Hz | RoboClaw encoder rate unlimited |
+| Fault check | ≥ 10 Hz | Limited by current sensor read rate |
+| Telemetry publish | ≥ 5 Hz | Wi-Fi bandwidth >> required |
+| Battery monitor | ≥ 1 Hz | Adequate for slow SoC changes |

--- a/systems_engineering/05_epbs/README.md
+++ b/systems_engineering/05_epbs/README.md
@@ -1,0 +1,100 @@
+# EPBS Architecture — End Product Breakdown Structure
+
+**Arcadia Layer 5 of 5**
+
+The EPBS Architecture answers the question: **WHAT is actually built and delivered?** It defines the **product breakdown structure** — the configuration items (CIs) that are procured, manufactured, or integrated to produce the final system.
+
+## Purpose
+
+The EPBS provides the formal breakdown of the OSR into deliverable, controllable items. It is the bridge between engineering models and the physical "thing you can put on a shelf." Each Configuration Item (CI) traces to a Physical Component and can be independently:
+
+- **Identified** (part number, supplier reference)
+- **Acquired** (purchased or manufactured)
+- **Tested** (acceptance criteria)
+- **Replaced** (in case of failure)
+
+## Documents
+
+| Document | Contents |
+|---|---|
+| [Configuration Items](configuration_items.md) | Complete product breakdown with part numbers |
+
+## Product Tree (Top Level)
+
+```
+OSR System (CI-00)
+├── CI-01  Mechanical Assembly
+│   ├── CI-01.1  Body Frame Kit
+│   ├── CI-01.2  Rocker-Bogie Suspension Kit
+│   ├── CI-01.3  Wheel Assembly Kit (×6)
+│   └── CI-01.4  Corner Steering Assembly Kit (×4)
+├── CI-02  Electronics Assembly
+│   ├── CI-02.1  Compute Module (Raspberry Pi 4B)
+│   ├── CI-02.2  Control PCB
+│   ├── CI-02.3  Motor Controller Kit (RoboClaw ×3)
+│   ├── CI-02.4  Servo Driver (PCA9685)
+│   ├── CI-02.5  IMU Module
+│   ├── CI-02.6  Camera Module
+│   └── CI-02.7  Wiring Harness Kit
+├── CI-03  Power Assembly
+│   ├── CI-03.1  Battery Pack (3S LiPo)
+│   └── CI-03.2  Battery Charger
+├── CI-04  Software
+│   ├── CI-04.1  Raspberry Pi OS Image
+│   └── CI-04.2  OSR ROS Software Package
+└── CI-05  Fastener and Hardware Kit
+    ├── CI-05.1  Structural Fasteners
+    ├── CI-05.2  Bearings and Inserts
+    └── CI-05.3  Wiring Hardware
+```
+
+## CI Realization Traceability
+
+| CI ID | Configuration Item | Physical Component Realized |
+|---|---|---|
+| CI-01.1 | Body Frame Kit | PC-MECH-01 |
+| CI-01.2 | Rocker-Bogie Suspension Kit | PC-MECH-02 |
+| CI-01.3 | Wheel Assembly Kit (×6) | PC-MECH-03 |
+| CI-01.4 | Corner Steering Assembly Kit (×4) | PC-MECH-04 |
+| CI-02.1 | Raspberry Pi 4B | PC-COMP-01 |
+| CI-02.2 | Control PCB | PC-PCB-01 |
+| CI-02.3 | RoboClaw 2×15A (×3) | PC-MCTL-01 |
+| CI-02.4 | PCA9685 Servo Driver | PC-MCTL-02 support |
+| CI-02.5 | IMU Module | PC-SENS-01 |
+| CI-02.6 | Camera Module | PC-CAM-01 |
+| CI-02.7 | Wiring Harness | PC wiring |
+| CI-03.1 | Battery Pack | PC-PWR-01 |
+| CI-03.2 | Battery Charger | PC-PWR-02 |
+| CI-04.1 | RPi OS Image | PC-COMP-01 software |
+| CI-04.2 | OSR ROS Package | LC-01 through LC-08 |
+
+## Acceptance Criteria by CI Class
+
+### Mechanical CIs (CI-01.x)
+- All fasteners present and torqued per assembly guide
+- Rocker-bogie articulates freely through full range with no binding
+- All six wheels spin freely; no axial play > 1 mm
+
+### Electronics CIs (CI-02.x)
+- PCB passes continuity check on power rails
+- Each RoboClaw recognized by Basicmicro Motion Studio
+- IMU returns valid quaternion data at ≥ 50 Hz
+- Camera streams video at ≥ 10 fps
+
+### Power CIs (CI-03.x)
+- Battery charges to full (≥ 12.6V for 3S) without swelling
+- Charger terminates correctly at full charge
+
+### Software CIs (CI-04.x)
+- RPi boots to ROS environment without error
+- All ROS nodes launch and advertise expected topics
+- Test traverse: rover drives 1 m forward and returns on command
+
+## Build Readiness Reviews
+
+| Review | Milestone | Gate Criteria |
+|---|---|---|
+| **MRR** — Mechanical Readiness Review | After CI-01 assembly | All wheels ground-contacting on flat surface; suspension articulates |
+| **ERR** — Electrical Readiness Review | After CI-02 assembly | All motor controllers powered; RPi accessible via SSH |
+| **SRR** — Software Readiness Review | After CI-04 install | All nodes running; `/cmd_vel` commands produce motor motion |
+| **FCA** — Functional Configuration Audit | After full integration | All M-01 scenario success criteria met |

--- a/systems_engineering/05_epbs/configuration_items.md
+++ b/systems_engineering/05_epbs/configuration_items.md
@@ -1,0 +1,257 @@
+# Configuration Items
+
+**EPBS Layer — Configuration Item Register**
+
+Configuration Items (CIs) are the procurable and deliverable items that make up the OSR system. Each CI has a defined part number (or reference), supplier, quantity, unit cost estimate, and acceptance test.
+
+## CI-00 — OSR System (Top Level)
+
+| Attribute | Value |
+|---|---|
+| **Kind** | SystemCI (complete integrated rover) |
+| **Status** | Assembled from sub-CIs below |
+| **Acceptance** | Full functional configuration audit (FCA) |
+
+---
+
+## CI-01 — Mechanical Assembly
+
+### CI-01.1 — Body Frame Kit
+
+| Item | Description | Supplier / Reference | Qty | Unit Cost (approx.) |
+|---|---|---|---|---|
+| 80/20 1010 extrusion | 1" × 1" aluminum T-slot, various lengths | 80/20 Inc. | ~8 pc | $5–15/pc |
+| Body side plates | Laser-cut 6061 aluminum plate, 3 mm | Send-Cut-Send / OSR CAD files | 2 | $20–40 ea |
+| Body top/bottom plates | Laser-cut 6061 aluminum plate | Send-Cut-Send / OSR CAD files | 2 | $15–30 ea |
+| T-slot nuts (1/4-20) | For 1010 extrusion | 80/20 Inc. | 50 | Bulk |
+| Electronics mounting standoffs | M3 × 10 mm hex standoffs | McMaster-Carr | 20 | $0.50 ea |
+
+**Acceptance:** Assembled frame is rigid; no rack or twist > 2° across diagonal; all T-slot connections tight.
+
+---
+
+### CI-01.2 — Rocker-Bogie Suspension Kit
+
+| Item | Description | Supplier / Reference | Qty | Unit Cost (approx.) |
+|---|---|---|---|---|
+| Rocker arm (×2) | Aluminum tube + plate, laser cut/bent | OSR CAD files | 2 | $25 ea |
+| Bogie arm (×2) | Aluminum tube + plate | OSR CAD files | 2 | $20 ea |
+| Differential bar | Aluminum flat bar | OSR CAD files | 1 | $10 |
+| Shoulder screws M8 | Pivot pins for rocker/bogie joints | McMaster-Carr | 6 | $3 ea |
+| Flanged bearings 8 mm bore | Pivot bearings | VXB / Amazon | 12 | $2–4 ea |
+| Differential pivot shaft | 8 mm steel shaft, 200 mm | McMaster-Carr | 1 | $8 |
+
+**Acceptance:** Both rocker assemblies articulate ±30° freely; differential bar equalizes rocker motion symmetrically when one side is displaced.
+
+---
+
+### CI-01.3 — Wheel Assembly Kit (×6)
+
+| Item | Description | Supplier / Reference | Qty per wheel | Total Qty |
+|---|---|---|---|---|
+| Wheel hub | Aluminum, CNC turned | OSR CAD / SendCutSend | 1 | 6 |
+| Tire | Rubber or TPU 3D-printed | Amazon / Printed | 1 | 6 |
+| Drive motor | Nidec/Hurst DC motor w/ encoder, 12V | Nidec / OSR BOM | 1 | 6 |
+| Motor mount bracket | Aluminum plate, laser cut | OSR CAD files | 1 | 6 |
+| Motor shaft coupler | 6 mm to hub bore | Servocity | 1 | 6 |
+| Wheel axle bearing | Flanged 6 mm | VXB | 2 | 12 |
+
+**Acceptance:** Each wheel spins freely with < 1 N·m drag; encoder returns pulses when shaft rotated by hand.
+
+---
+
+### CI-01.4 — Corner Steering Assembly Kit (×4)
+
+| Item | Description | Supplier / Reference | Qty per corner | Total Qty |
+|---|---|---|---|---|
+| Steering bracket | Aluminum plate, laser cut | OSR CAD files | 1 | 4 |
+| Corner servo | Digital servo ≥ 15 kg·cm | Hitec / Savox | 1 | 4 |
+| Servo horn | Aluminum, keyed | Servocity | 1 | 4 |
+| Pivot bearing | Flanged 8 mm | VXB | 2 | 8 |
+| Steering shaft | 8 mm steel | McMaster-Carr | 1 | 4 |
+
+**Acceptance:** Each corner steers ±30° on servo command; no binding in pivot bearings.
+
+---
+
+## CI-02 — Electronics Assembly
+
+### CI-02.1 — Compute Module
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| Raspberry Pi 4B 4 GB | SBC | Raspberry Pi Ltd / Adafruit | 1 | ~$55 |
+| MicroSD Card 32 GB+ | Storage | Samsung / SanDisk | 1 | $8–12 |
+| USB-C Power Cable | 5V/3A, ≤ 0.5 m | Amazon | 1 | $5 |
+| Heatsink kit | Passive cooling | Amazon | 1 | $5 |
+
+**Acceptance:** RPi boots to Linux prompt; SSH accessible; Wi-Fi connects to test AP.
+
+---
+
+### CI-02.2 — Control PCB
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| OSR Control PCB (bare) | Custom PCB gerbers | JLCPCB / OSH Park | 1 | $15–40 |
+| DC-DC Buck Converter 5V | LM2596 or equivalent | OSR BOM | 1 | $5 |
+| INA219 current sensor | I²C power monitor | Adafruit | 1 | $8 |
+| XT60 female connector | Battery input | Amazon | 1 | $2 |
+| Blade fuse holder + 30A fuse | In-line protection | Amazon | 1 | $3 |
+| Screw terminals | Motor/power outputs | DigiKey | 10 | $0.50 ea |
+
+**Acceptance:** 5V rail within ±0.25V under 3A load; INA219 readable over I²C; no shorts on motor outputs.
+
+---
+
+### CI-02.3 — Motor Controller Kit
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| RoboClaw 2×15A | Dual DC motor controller | Basicmicro | 3 | ~$130 ea |
+| USB-B cable | Controller connection | Amazon | 3 | $5 ea |
+
+**Acceptance:** Each unit recognized at unique serial address; motor channels respond to speed commands; encoder counts increment correctly.
+
+---
+
+### CI-02.4 — Servo Driver
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| PCA9685 16-ch PWM module | I²C servo driver | Adafruit #815 | 1 | $7 |
+
+**Acceptance:** I²C communication confirmed; servo moves to commanded angle.
+
+---
+
+### CI-02.5 — IMU Module
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| BNO055 9-DOF IMU breakout | Absolute orientation sensor | Adafruit #2472 | 1 | $35 |
+| Qwiic/I²C cable | 100 mm | Adafruit / SparkFun | 1 | $3 |
+
+**Acceptance:** BNO055 returns stable quaternion at 100 Hz; orientation matches physical rover attitude within 5°.
+
+---
+
+### CI-02.6 — Camera Module
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| Raspberry Pi Camera Module 3 | 12 MP, CSI-2 | Raspberry Pi Ltd | 1 | $25 |
+| CSI ribbon cable 200 mm | Camera to RPi | Amazon | 1 | $3 |
+| Camera mount bracket | 3D-printed or aluminum | OSR CAD files | 1 | $2 |
+
+**Acceptance:** Camera streams 1080p video at ≥ 15 fps; image focused at 0.5–2 m range.
+
+---
+
+### CI-02.7 — Wiring Harness Kit
+
+| Item | Description | Gauge | Qty |
+|---|---|---|---|
+| Battery cable (12V main) | XT60 to PCB | 12 AWG silicone | 1 harness |
+| Motor power cables | PCB to RoboClaw | 14 AWG | 3 harnesses |
+| Motor lead cables | RoboClaw to motors | 18 AWG | 6 pairs |
+| Servo extension cables | PCA9685 to servos | 22 AWG | 4 × 400 mm |
+| I²C cables | RPi to IMU, PCA9685 | 24 AWG | 2 × 200 mm |
+| GPIO ribbon | RPi to PCB | 26 AWG ribbon | 1 |
+
+---
+
+## CI-03 — Power Assembly
+
+### CI-03.1 — Battery Pack
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| 3S LiPo 5200 mAh 20C | Main rover battery | Zeee / Tattu / Gens ace | 1 | $30–50 |
+| XT60 male plug | Battery pigtail | Amazon | 1 | $2 |
+
+**Acceptance:** Charges to 12.6V; no swelling during charge; holds charge ≥ 6 hours on shelf.
+
+---
+
+### CI-03.2 — Battery Charger
+
+| Item | Description | Supplier | Qty | Unit Cost |
+|---|---|---|---|---|
+| 3S LiPo balance charger | Up to 6A charge rate | SkyRC B6 / iCharger | 1 | $35–80 |
+| Power supply (AC adapter) | For charger input | Included or separate | 1 | — |
+
+---
+
+## CI-04 — Software
+
+### CI-04.1 — Raspberry Pi OS Image
+
+| Attribute | Value |
+|---|---|
+| **Base OS** | Raspberry Pi OS Bullseye (64-bit) |
+| **Version** | Latest at time of build |
+| **Installation** | Raspberry Pi Imager → microSD |
+| **URL** | https://www.raspberrypi.com/software/ |
+
+### CI-04.2 — OSR ROS Software Package
+
+| Attribute | Value |
+|---|---|
+| **Repository** | https://github.com/nasa-jpl/osr-rover-code |
+| **Branch** | `master` |
+| **ROS version** | Noetic (Ubuntu 20.04) or Humble (Ubuntu 22.04) |
+| **Installation** | `git clone` + `catkin_make` per software README |
+| **Nodes** | See [Physical Functions](../04_physical_architecture/physical_functions.md) |
+
+---
+
+## CI-05 — Fastener and Hardware Kit
+
+### CI-05.1 — Structural Fasteners
+
+| Item | Standard | Qty |
+|---|---|---|
+| M3 × 8 SHCS | DIN 912 | 50 |
+| M3 × 12 SHCS | DIN 912 | 30 |
+| M3 × 20 SHCS | DIN 912 | 20 |
+| M3 hex nut | DIN 934 | 100 |
+| M3 lock nut | DIN 985 | 50 |
+| M4 × 10 SHCS | DIN 912 | 30 |
+| M4 × 16 SHCS | DIN 912 | 20 |
+| M4 hex nut | DIN 934 | 50 |
+| 1/4-20 × 3/4 BHCS | Imperial, T-slot | 30 |
+| 1/4-20 T-nut | For 1010 extrusion | 30 |
+| M8 shoulder screw 30 mm | Pivot pins | 6 |
+
+### CI-05.2 — Bearings and Inserts
+
+| Item | Standard | Qty |
+|---|---|---|
+| Flanged ball bearing 8 mm bore | F608ZZ | 16 |
+| Flanged ball bearing 6 mm bore | F606ZZ | 12 |
+| M3 heat-set insert | For 3D-printed parts | 30 |
+
+### CI-05.3 — Wiring Hardware
+
+| Item | Description | Qty |
+|---|---|---|
+| XT60 connectors (pair) | Battery/motor power | 5 |
+| JST-PH 2-pin | Signal/sensor power | 10 |
+| Wire ferrules | For screw terminals | 50 |
+| Zip ties 100 mm | Cable management | 50 |
+| Cable sleeves | Braided, 6 mm | 1 m |
+| Heat shrink (assorted) | 2–8 mm | 1 kit |
+
+## Total Estimated Build Cost
+
+| Category | Estimated Cost (USD) |
+|---|---|
+| Mechanical (CI-01) | $350–500 |
+| Electronics (CI-02) | $600–800 |
+| Power (CI-03) | $70–130 |
+| Software (CI-04) | $0 (open source) |
+| Fasteners (CI-05) | $80–120 |
+| **Total** | **$1,100–1,550** |
+
+*Costs vary by supplier, region, and whether optional parts (e.g., camera) are included.*

--- a/systems_engineering/MBSE_workspace/.gitignore
+++ b/systems_engineering/MBSE_workspace/.gitignore
@@ -1,0 +1,1 @@
+/.metadata/

--- a/systems_engineering/MBSE_workspace/OSR_capella_model/.project
+++ b/systems_engineering/MBSE_workspace/OSR_capella_model/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+    <name>OSR_capella_model</name>
+    <comment></comment>
+    <projects>
+    </projects>
+    <buildSpec>
+    </buildSpec>
+    <natures>
+        <nature>org.polarsys.capella.project.nature</nature>
+    </natures>
+</projectDescription>

--- a/systems_engineering/MBSE_workspace/OSR_capella_model/OSR_capella_model.afm
+++ b/systems_engineering/MBSE_workspace/OSR_capella_model/OSR_capella_model.afm
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0"
+    id="_9Q90MOlFEe6ZgIZX90rCwQ">
+  <viewpointReferences id="_szboOlFEe6ZgIZX90rCwQ"
+      vpId="org.polarsys.capella.core.viewpoint"
+      version="6.1.0"/>
+</metadata:Metadata>

--- a/systems_engineering/MBSE_workspace/OSR_capella_model/OSR_capella_model.aird
+++ b/systems_engineering/MBSE_workspace/OSR_capella_model/OSR_capella_model.aird
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<viewpoint:DAnalysis xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:description="http://www.eclipse.org/sirius/description/1.1.0"
+    xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0"
+    uid="_9RCFoOlFEe6ZgIZX90rCwQ"
+    selectedViews="_9uI4YOlFEe6ZgIZX90rCwQ _9ve8MOlFEe6ZgIZX90rCwQ _92-rUOlFEe6ZgIZX90rCwQ _93isAOlFEe6ZgIZX90rCwQ _94QdsOlFEe6ZgIZX90rCwQ _96WvcOlFEe6ZgIZX90rCwQ _97f-8OlFEe6ZgIZX90rCwQ"
+    version="15.1.0.202211301600">
+  <semanticResources>OSR_capella_model.afm</semanticResources>
+  <semanticResources>OSR_capella_model.capella</semanticResources>
+  <ownedViews uid="_9uI4YOlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+  </ownedViews>
+  <ownedViews uid="_9ve8MOlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+  </ownedViews>
+  <ownedViews uid="_92-rUOlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+  </ownedViews>
+  <ownedViews uid="_93isAOlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+  </ownedViews>
+  <ownedViews uid="_94QdsOlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+  </ownedViews>
+  <ownedViews uid="_96WvcOlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+  </ownedViews>
+  <ownedViews uid="_97f-8OlFEe6ZgIZX90rCwQ">
+    <viewpoint href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+  </ownedViews>
+</viewpoint:DAnalysis>

--- a/systems_engineering/MBSE_workspace/OSR_capella_model/OSR_capella_model.capella
+++ b/systems_engineering/MBSE_workspace/OSR_capella_model/OSR_capella_model.capella
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Capella_Version_6.1.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:libraries="http://www.polarsys.org/capella/common/libraries/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/6.0.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/6.0.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/6.0.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/6.0.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/6.0.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/6.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/6.0.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/6.0.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/6.0.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/6.0.0"
+    id="382879fb-9f9e-49a6-b613-c4090197549c"
+    name="OSR_capella_model">
+  <ownedExtensions xsi:type="libraries:ModelInformation"
+      id="792bdb0d-429a-4be5-88a2-86493656961d"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="fb39e72f-7a82-4d4f-a84c-6608e258cb71"
+      name="ProgressStatus">
+    <ownedLiterals id="f8da2d96-2595-4331-96de-8f0f4c29402a" name="DRAFT"/>
+    <ownedLiterals id="aaf352b9-a695-46ec-9a39-8203f8c7bd83" name="TO_BE_REVIEWED"/>
+    <ownedLiterals id="81649bd8-51b0-46c4-b83f-cb5a9e0cdf9f" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals id="3d7e8fb6-f869-4ae1-a4bf-8334a7d680cc" name="REWORK_NECESSARY"/>
+    <ownedLiterals id="7e11085b-c411-40c1-859e-84d602e43cba" name="UNDER_REWORK"/>
+    <ownedLiterals id="54215d92-1a55-4d1e-a982-ad65951c72bf" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs id="5fc8b8a8-1302-4080-bb25-3304013257e6"
+      key="projectApproach"
+      value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="2c685d20-f62f-4884-b207-056bb5f2467d"
+      name="OSR_capella_model">
+
+    <!-- ===== LAYER 1: OPERATIONAL ANALYSIS ===== -->
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="1ac666ab-1afe-4aaf-879f-7bc4af137a8f"
+        name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:RootActivityPkg"
+          id="4388b005-675c-413e-8764-dbd7f043cb18"
+          name="Operational Activities">
+        <ownedOperationalActivities id="b09e9896-7edf-4ac0-aae8-00f368ecef94"
+            name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="2c1cf999-c595-443b-8ea2-f1746440a579"
+          name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="740dbaf6-8f74-413f-b684-fec5df8be975"
+          name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="da04821d-20d0-4b2a-bfec-ac95a17c5603"
+          name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg"
+          id="05f20436-bc6e-40b8-8165-ce6f2aaeba1e"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg"
+          id="8922e142-553f-4747-a9ab-268a146f90e7"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+
+    <!-- ===== LAYER 2: SYSTEM ANALYSIS ===== -->
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="6fbd9a52-0478-48cd-9b2b-49bb3af03a94"
+        name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="8cb89079-666c-43b2-8d4c-e59f7526818f"
+          name="System Functions">
+        <ownedSystemFunctions id="60a5c18f-74f5-4beb-b1ff-9d9bbd472d25"
+            name="Root System Function">
+          <ownedFunctionRealizations id="2d333aab-cc98-4c36-bd3c-4101d6444403"
+              targetElement="#b09e9896-7edf-4ac0-aae8-00f368ecef94"
+              sourceElement="#60a5c18f-74f5-4beb-b1ff-9d9bbd472d25"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="4af6fec2-1650-4a18-b7d3-a691c97dfae9"
+          name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="6618bc5f-d07f-4efd-82a8-fa9d5432940e"
+          name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="d0371017-7bce-4c99-bf29-75f76865dab4"
+          name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="4905fdd7-2753-41e6-a65f-446d130f3886"
+            name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="01df2fd1-e6e3-4236-a27a-b5f5b6c33c4b"
+              name="Boolean"
+              visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="a06c4a34-3a65-4e60-bac1-42f41c694133"
+              name="Byte"
+              visibility="PUBLIC"
+              kind="INTEGER">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="ba38e940-4e30-41b3-aabc-5df9d9e5e6af"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="c3e04b11-5b2a-4e9c-b1f0-8d6e2c3a1b2c"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="fa156203-7d92-4b1a-bc80-3e0f5e77c123"
+              name="Char"
+              visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="d4e15f22-6c3b-4f9d-a2e1-9b7c4d5e6f7a"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="e5f26g33-7d4c-5a0e-b3f2-0c8d5e6f7a8b"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="e45cd126-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+              name="Double"
+              visibility="PUBLIC"
+              kind="FLOAT"
+              discrete="false"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="50317265-2b3c-4d5e-6f7a-8b9c0d1e2f3a"
+              name="Float"
+              visibility="PUBLIC"
+              kind="FLOAT"
+              discrete="false"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="3cbc0361-3c4d-5e6f-7a8b-9c0d1e2f3a4b"
+              name="Hexadecimal"
+              visibility="PUBLIC"
+              kind="INTEGER">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="4d5e6f7a-4d5e-6f7a-8b9c-0d1e2f3a4b5c"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="64255554-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+              name="Integer"
+              visibility="PUBLIC"
+              kind="INTEGER"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="257ad620-6f7a-8b9c-0d1e-2f3a4b5c6d7e"
+              name="Long"
+              visibility="PUBLIC"
+              kind="INTEGER"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="61f31d82-7a8b-9c0d-1e2f-3a4b5c6d7e8f"
+              name="LongLong"
+              visibility="PUBLIC"
+              kind="INTEGER"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="3c85e0da-8b9c-0d1e-2f3a-4b5c6d7e8f9a"
+              name="Short"
+              visibility="PUBLIC"
+              kind="INTEGER"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="9e7d189d-9c0d-1e2f-3a4b-5c6d7e8f9a0b"
+              name="String"
+              visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5dc80ba2-0d1e-2f3a-4b5c-6d7e8f9a0b1c"
+              name="UnsignedInteger"
+              visibility="PUBLIC"
+              kind="INTEGER">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="6ed91cb3-1e2f-3a4b-5c6d-7e8f9a0b1c2d"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="50292719-2f3a-4b5c-6d7e-8f9a0b1c2d3e"
+              name="UnsignedShort"
+              visibility="PUBLIC"
+              kind="INTEGER">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="7fe02dc4-3a4b-5c6d-7e8f-9a0b1c2d3e4f"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="f95689d1-4b5c-6d7e-8f9a-0b1c2d3e4f5a"
+              name="UnsignedLong"
+              visibility="PUBLIC"
+              kind="INTEGER">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="8af13ed5-5c6d-7e8f-9a0b-1c2d3e4f5a6b"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="6ac1e2dc-5c6d-7e8f-9a0b-1c2d3e4f5a6b"
+              name="UnsignedLongLong"
+              visibility="PUBLIC"
+              kind="INTEGER">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="9b024fe6-6d7e-8f9a-0b1c-2d3e4f5a6b7c"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="a47bd454-ecc8-4d20-991a-b8dfb67e5828"
+          name="Structure">
+        <ownedParts id="e0dd1fb8-7a8b-9c0d-1e2f-3a4b5c6d7e8f"
+            name="System"
+            abstractType="#3183326b-ff3d-4163-8353-3e5a1df12e89"/>
+        <ownedSystemComponents id="3183326b-ff3d-4163-8353-3e5a1df12e89"
+            name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="a35b7a4b-8b9c-0d1e-2f3a-4b5c6d7e8f9a"
+              name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="3d6d7a4e-9c0d-1e2f-3a4b-5c6d7e8f9a0b"
+                name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg"
+          id="70466143-7f38-43b9-afa4-fc3cb8a55bb7"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations id="702ea61a-0d1e-2f3a-4b5c-6d7e8f9a0b1c"
+          targetElement="#1ac666ab-1afe-4aaf-879f-7bc4af137a8f"
+          sourceElement="#6fbd9a52-0478-48cd-9b2b-49bb3af03a94"/>
+    </ownedArchitectures>
+
+    <!-- ===== LAYER 3: LOGICAL ARCHITECTURE ===== -->
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="664d9641-58f1-4945-8e03-f7b98644a30d"
+        name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="3c2f6ac8-837e-4e1e-b057-53c2961d2431"
+          name="Logical Functions">
+        <ownedLogicalFunctions id="d2533d31-07f2-4e27-b725-522e1d407568"
+            name="Root Logical Function">
+          <ownedFunctionRealizations id="e050ea15-1e2f-3a4b-5c6d-7e8f9a0b1c2d"
+              targetElement="#60a5c18f-74f5-4beb-b1ff-9d9bbd472d25"
+              sourceElement="#d2533d31-07f2-4e27-b725-522e1d407568"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="db91feb3-2f3a-4b5c-6d7e-8f9a0b1c2d3e"
+          name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="e6d31290-3a4b-5c6d-7e8f-9a0b1c2d3e4f"
+          name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="3531fbe3-4b5c-6d7e-8f9a-0b1c2d3e4f5a"
+          name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="78f38782-c323-474c-bdfe-39ab80436e0a"
+          name="Structure">
+        <ownedParts id="6d74d211-5c6d-7e8f-9a0b-1c2d3e4f5a6b"
+            name="Logical System"
+            abstractType="#226ae547-1185-4f75-acf3-7402fbeaae11"/>
+        <ownedLogicalComponents id="226ae547-1185-4f75-acf3-7402fbeaae11"
+            name="Logical System">
+          <ownedComponentRealizations id="e50cb970-6d7e-8f9a-0b1c-2d3e4f5a6b7c"
+              targetElement="#3183326b-ff3d-4163-8353-3e5a1df12e89"
+              sourceElement="#226ae547-1185-4f75-acf3-7402fbeaae11"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations id="5460d99d-7e8f-9a0b-1c2d-3e4f5a6b7c8d"
+          targetElement="#6fbd9a52-0478-48cd-9b2b-49bb3af03a94"
+          sourceElement="#664d9641-58f1-4945-8e03-f7b98644a30d"/>
+    </ownedArchitectures>
+
+    <!-- ===== LAYER 4: PHYSICAL ARCHITECTURE ===== -->
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="017a1c6e-b28d-4fbb-9ec7-61686d6cd670"
+        name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="6293bb3e-969e-4ec3-a7a0-0214d04d0c49"
+          name="Physical Functions">
+        <ownedPhysicalFunctions id="6e89423f-a6f5-4001-8be9-8e5cf6e27e3c"
+            name="Root Physical Function">
+          <ownedFunctionRealizations id="838383b6-8f9a-0b1c-2d3e-4f5a6b7c8d9e"
+              targetElement="#d2533d31-07f2-4e27-b725-522e1d407568"
+              sourceElement="#6e89423f-a6f5-4001-8be9-8e5cf6e27e3c"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="7baf2cb8-9a0b-1c2d-3e4f-5a6b7c8d9e0f"
+          name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="a7636c7b-0b1c-2d3e-4f5a-6b7c8d9e0f1a"
+          name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="f00052c8-1c2d-3e4f-5a6b-7c8d9e0f1a2b"
+          name="Data"/>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="b1f464a8-54c1-4e88-9857-5bf228177cc3"
+          name="Structure">
+        <ownedParts id="a0012c5d-2d3e-4f5a-6b7c-8d9e0f1a2b3c"
+            name="Physical System"
+            abstractType="#235eb4bd-deef-4e70-8425-293fceb2d019"/>
+        <ownedPhysicalComponents id="235eb4bd-deef-4e70-8425-293fceb2d019"
+            name="Physical System">
+          <ownedComponentRealizations id="2f1cb947-3e4f-5a6b-7c8d-9e0f1a2b3c4d"
+              targetElement="#226ae547-1185-4f75-acf3-7402fbeaae11"
+              sourceElement="#235eb4bd-deef-4e70-8425-293fceb2d019"/>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations id="ee486b51-4f5a-6b7c-8d9e-0f1a2b3c4d5e"
+          targetElement="#664d9641-58f1-4945-8e03-f7b98644a30d"
+          sourceElement="#017a1c6e-b28d-4fbb-9ec7-61686d6cd670"/>
+    </ownedArchitectures>
+
+    <!-- ===== LAYER 5: EPBS ARCHITECTURE ===== -->
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="32eb162f-ee45-4b21-a91e-0611caff982a"
+        name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="19ea0d27-5a6b-7c8d-9e0f-1a2b3c4d5e6f"
+          name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="a8d91cf8-4ab7-406b-a0f8-db828a92fd21"
+          name="Structure">
+        <ownedParts id="1cb36d5a-6b7c-8d9e-0f1a-2b3c4d5e6f7a"
+            name="System"
+            abstractType="#1c90fcc2-b48f-4b07-b710-45f534e6cd34"/>
+        <ownedConfigurationItems id="1c90fcc2-b48f-4b07-b710-45f534e6cd34"
+            name="System"
+            kind="System">
+          <ownedPhysicalArtifactRealizations id="8853599f-7c8d-9e0f-1a2b-3c4d5e6f7a8b"
+              targetElement="#235eb4bd-deef-4e70-8425-293fceb2d019"
+              sourceElement="#1c90fcc2-b48f-4b07-b710-45f534e6cd34"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations id="8c4bf98f-8d9e-0f1a-2b3c-4d5e6f7a8b9c"
+          targetElement="#017a1c6e-b28d-4fbb-9ec7-61686d6cd670"
+          sourceElement="#32eb162f-ee45-4b21-a91e-0611caff982a"/>
+    </ownedArchitectures>
+
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/systems_engineering/MBSE_workspace/README.md
+++ b/systems_engineering/MBSE_workspace/README.md
@@ -1,0 +1,144 @@
+# MBSE Workspace — Capella Model
+
+This directory contains the machine-readable **Eclipse Capella** MBSE model for the JPL Open Source Rover. The model implements the complete Arcadia methodology across all five engineering layers.
+
+## Capella Model Source
+
+The model originates from [PhilCarPi/open-source-rover](https://github.com/PhilCarPi/open-source-rover/tree/master/systems_engineering/MBSE_workspace) (Capella 6.1.0, project approach: SingletonComponents).
+
+## Directory Contents
+
+```
+MBSE_workspace/
+├── README.md                          ← This file
+└── OSR_capella_model/
+    ├── .project                       ← Eclipse project descriptor
+    ├── OSR_capella_model.afm          ← Kitalpha Architecture Framework Metadata
+    ├── OSR_capella_model.aird         ← Sirius diagram registry (viewpoints)
+    └── OSR_capella_model.capella      ← Primary semantic model (XMI/XML)
+```
+
+## Opening the Model
+
+### Prerequisites
+
+1. Download **Eclipse Capella 6.1.0** from [mbse-capella.org](https://mbse-capella.org/download.html)
+2. Extract the archive — no installation required
+
+### Import Steps
+
+1. Launch Capella
+2. Select **File → Import → General → Existing Projects into Workspace**
+3. Click **Browse** and navigate to this `MBSE_workspace/` folder
+4. Check `OSR_capella_model` and click **Finish**
+5. The model appears in the **Project Explorer** pane
+
+### Model Structure in Capella
+
+```
+OSR_capella_model (Project)
+└── OSR_capella_model (System Engineering root)
+    ├── Operational Analysis
+    │   ├── Operational Activities
+    │   │   └── Root Operational Activity
+    │   ├── Operational Entities
+    │   ├── Operational Capabilities
+    │   └── Roles
+    ├── System Analysis
+    │   ├── System Functions
+    │   │   └── Root System Function
+    │   ├── Structure → System component
+    │   ├── Capabilities
+    │   ├── Missions
+    │   └── Data
+    ├── Logical Architecture
+    │   ├── Logical Functions
+    │   │   └── Root Logical Function
+    │   ├── Structure → Logical System
+    │   └── Interfaces
+    ├── Physical Architecture
+    │   ├── Physical Functions
+    │   │   └── Root Physical Function
+    │   ├── Structure → Physical System
+    │   └── Interfaces
+    └── EPBS Architecture
+        └── Structure → System (SystemCI)
+```
+
+## Capella Viewpoints Active
+
+The `.aird` file registers seven Capella viewpoints:
+
+| Viewpoint | Purpose |
+|---|---|
+| Kitalpha AD | Architecture description |
+| System Analysis | SA diagrams (SAB, SDFB, MSM) |
+| EPBS Architecture | Product breakdown diagrams |
+| Logical Architecture | LA diagrams (LAB, LDFB) |
+| Common | Shared elements |
+| Operational Analysis | OA diagrams (OAB, OES, OPD) |
+| Physical Architecture | PA diagrams (PAB, PDFB) |
+
+## Recommended Diagrams to Create
+
+As the model is populated with OSR-specific content, create these diagrams in Capella:
+
+### Operational Analysis
+- **OAB** (Operational Architecture Block): Show all operational entities and interactions
+- **OES** (Operational Entity Scenario): Show M-01 nominal mission sequence
+- **OPD** (Operational Process Description): Show activity flows
+
+### System Analysis
+- **SAB** (System Architecture Block): System with all external interfaces
+- **MSM** (Modes and States Machine): System state machine (OFF, BOOTING, STANDBY, EXECUTING, SAFE STOP)
+- **SDFB** (System Data Flow Blank): SF function chain
+
+### Logical Architecture
+- **LAB** (Logical Architecture Block): All 8 logical components and connections
+- **LDFB** (Logical Data Flow Blank): Function chain through components
+
+### Physical Architecture
+- **PAB** (Physical Architecture Block): RPi, PCB, RoboClaws, sensors
+- **PDFB** (Physical Data Flow Blank): ROS node data flows
+
+### EPBS
+- **EAB** (EPBS Architecture Block): Product breakdown tree
+
+## Traceability Chains in the Model
+
+The scaffold model already defines the full vertical realization chain:
+
+```
+EPBS: System (SystemCI)
+  └── realizes ──► PA: Physical System
+        └── realizes ──► LA: Logical System
+              └── realizes ──► SA: System
+
+Root Physical Function
+  └── realizes ──► Root Logical Function
+        └── realizes ──► Root System Function
+              └── realizes ──► Root Operational Activity
+```
+
+## Expanding the Model
+
+To populate OSR-specific content into the Capella model, follow this workflow:
+
+1. **OA Layer:** Create named Operational Entities (OE-01 through OE-10 per [operational_entities.md](../01_operational_analysis/operational_entities.md)). Add Operational Activities as children of Root Operational Activity.
+
+2. **SA Layer:** Decompose Root System Function into SF-01 through SF-07 per [system_functions.md](../02_system_analysis/system_functions.md). Define interfaces at the System boundary.
+
+3. **LA Layer:** Decompose Logical System into LC-01 through LC-08 per [logical_components.md](../03_logical_architecture/logical_components.md). Allocate logical functions.
+
+4. **PA Layer:** Decompose Physical System into physical components per [physical_components.md](../04_physical_architecture/physical_components.md). Deploy physical functions.
+
+5. **EPBS Layer:** Create Configuration Item children per [configuration_items.md](../05_epbs/configuration_items.md).
+
+## Model File Notes
+
+The `.capella` file uses **XMI 2.0** format with Capella 6.0.0 namespaces. It is a standard XML file and can be inspected with any text editor, though Capella should be used for editing to maintain referential integrity (all elements reference each other by UUID).
+
+The `ProgressStatus` enumeration in the model supports these values:
+`DRAFT | TO_BE_REVIEWED | TO_BE_DISCUSSED | REWORK_NECESSARY | UNDER_REWORK | REVIEWED_OK`
+
+Use these to track the maturity of model elements as the OSR MBSE effort progresses.

--- a/systems_engineering/README.md
+++ b/systems_engineering/README.md
@@ -1,0 +1,64 @@
+# Systems Engineering — JPL Open Source Rover
+
+This directory contains the Model-Based Systems Engineering (MBSE) documentation for the JPL Open Source Rover (OSR) project. The documentation follows the **Arcadia/Capella methodology**, a rigorous top-down systems engineering approach that traces requirements from stakeholder needs through physical implementation.
+
+## MBSE Methodology: Arcadia
+
+The OSR systems engineering model is structured around the **Arcadia** methodology implemented in [Eclipse Capella](https://mbse-capella.org/). Arcadia organizes a system's description into five successive engineering levels, each refining the previous:
+
+```
+┌─────────────────────────────────────────┐
+│  1. Operational Analysis (OA)           │  WHY — stakeholder needs & context
+├─────────────────────────────────────────┤
+│  2. System Analysis (SA)                │  WHAT — system functions & boundary
+├─────────────────────────────────────────┤
+│  3. Logical Architecture (LA)           │  HOW (abstract) — solution concepts
+├─────────────────────────────────────────┤
+│  4. Physical Architecture (PA)          │  HOW (concrete) — physical design
+├─────────────────────────────────────────┤
+│  5. EPBS Architecture                   │  WHAT IS BUILT — product breakdown
+└─────────────────────────────────────────┘
+```
+
+Each layer maintains **vertical traceability** — every physical component traces back to a logical component, which traces back to a system function, which traces back to an operational need.
+
+## Document Structure
+
+| Directory | Arcadia Layer | Purpose |
+|---|---|---|
+| [01_operational_analysis/](01_operational_analysis/README.md) | OA | Stakeholders, operational activities, entities |
+| [02_system_analysis/](02_system_analysis/README.md) | SA | System functions, capabilities, missions |
+| [03_logical_architecture/](03_logical_architecture/README.md) | LA | Logical subsystems, function allocation |
+| [04_physical_architecture/](04_physical_architecture/README.md) | PA | Physical components, deployment |
+| [05_epbs/](05_epbs/README.md) | EPBS | Product breakdown, configuration items |
+| [MBSE_workspace/](MBSE_workspace/README.md) | — | Capella model files (machine-readable) |
+
+## Capella Model
+
+The machine-readable Capella model lives in [MBSE_workspace/](MBSE_workspace/README.md). To open it:
+
+1. Download [Eclipse Capella 6.1.0](https://mbse-capella.org/download.html)
+2. Open Capella and select **File → Import → Existing Projects into Workspace**
+3. Point to the `MBSE_workspace/OSR_capella_model/` folder
+4. The model opens with five architecture layers in the Project Explorer
+
+The Markdown documents in this directory are generated/maintained in parallel with the Capella model and serve as the human-readable representation.
+
+## Key Abbreviations
+
+| Term | Meaning |
+|---|---|
+| OA | Operational Analysis |
+| OE | Operational Entity |
+| OAct | Operational Activity |
+| SA | System Analysis |
+| SF | System Function |
+| LA | Logical Architecture |
+| LC | Logical Component |
+| LF | Logical Function |
+| PA | Physical Architecture |
+| PC | Physical Component |
+| PF | Physical Function |
+| EPBS | End Product Breakdown Structure |
+| CI | Configuration Item |
+| MBSE | Model-Based Systems Engineering |


### PR DESCRIPTION
## Summary

- Introduces a full 5-layer **Arcadia/Capella MBSE** structure for the JPL Open Source Rover, following the same methodology used on real Mars rover programs
- Adds 22 documentation pages covering the complete traceability chain from stakeholder needs → system functions → logical components → physical hardware → product breakdown
- Includes the Eclipse Capella 6.1.0 model scaffold (`.capella`, `.aird`, `.afm`) sourced from [PhilCarPi/open-source-rover](https://github.com/PhilCarPi/open-source-rover/tree/master/systems_engineering/MBSE_workspace)
- Updates `mkdocs.yml` with a full Systems Engineering nav section (22 pages)

## Structure Added

```
systems_engineering/
├── 01_operational_analysis/   — Stakeholders, entities, activities, capabilities
├── 02_system_analysis/        — System functions, capabilities, missions, interfaces
├── 03_logical_architecture/   — 8 logical components (LC-01..LC-08), functions, interfaces
├── 04_physical_architecture/  — RPi/RoboClaw/PCB component specs, ROS node deployment map
├── 05_epbs/                   — Full BOM with suppliers and cost estimates (~$1,100–1,550)
└── MBSE_workspace/            — Capella 6.1.0 model files (machine-readable)
```

## Test plan

- [x] `mkdocs build` passes with zero new warnings (7 pre-existing warnings in repo are unaffected)
- [x] All 22 systems engineering HTML pages rendered in `_site/systems_engineering/`
- [x] Capella model files include valid XMI scaffold for all 5 Arcadia layers
- [ ] ReadTheDocs build passes on PR (automated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)